### PR TITLE
feat: Add feature to send error messages to slack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     // Database
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Slack-Api
+    implementation 'net.gpedro.integrations.slack:slack-webhook:1.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/twoclock/gitconnect/global/config/SlackLogAppenderConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/SlackLogAppenderConfig.java
@@ -1,0 +1,18 @@
+package com.twoclock.gitconnect.global.config;
+
+import net.gpedro.integrations.slack.SlackApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SlackLogAppenderConfig {
+
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
+
+    @Bean
+    public SlackApi slackApi() {
+        return new SlackApi(webhookUrl);
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/global/config/ThreadPoolConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/ThreadPoolConfig.java
@@ -1,0 +1,23 @@
+package com.twoclock.gitconnect.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class ThreadPoolConfig {
+
+    private static final int MAX_POOL_SIZE = 5; // 최대 스레드 수
+    private static final int CORE_POOL_SIZE = 5; // 기본 스레드 수
+
+    @Bean
+    public ThreadPoolTaskExecutor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+        threadPoolTaskExecutor.setMaxPoolSize(MAX_POOL_SIZE);
+        threadPoolTaskExecutor.setCorePoolSize(CORE_POOL_SIZE);
+        threadPoolTaskExecutor.initialize();
+        return threadPoolTaskExecutor;
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,10 @@
 package com.twoclock.gitconnect.global.exception;
 
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import com.twoclock.gitconnect.global.slack.annotation.SlackNotification;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import net.gpedro.integrations.slack.SlackApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -8,10 +12,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    private final SlackApi slackApi;
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponseDto> handleBusinessException(CustomException e) {
@@ -22,8 +29,9 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(responseDto, e.getErrorCode().getHttpStatus());
     }
 
+    @SlackNotification
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponseDto> handleException(Exception e) {
+    public ResponseEntity<ErrorResponseDto> handleException(HttpServletRequest request, Exception e) {
         ErrorResponseDto responseDto =
                 new ErrorResponseDto(
                         ErrorCode.INTERNAL_SERVER_ERROR.getCode(),

--- a/src/main/java/com/twoclock/gitconnect/global/slack/annotation/SlackNotification.java
+++ b/src/main/java/com/twoclock/gitconnect/global/slack/annotation/SlackNotification.java
@@ -1,0 +1,11 @@
+package com.twoclock.gitconnect.global.slack.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SlackNotification {
+}

--- a/src/main/java/com/twoclock/gitconnect/global/slack/aspect/SlackNotificationAspect.java
+++ b/src/main/java/com/twoclock/gitconnect/global/slack/aspect/SlackNotificationAspect.java
@@ -10,19 +10,22 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 
 @RequiredArgsConstructor
-@Profile(value = "local")
+@Profile(value = "dev")
 @Aspect
 @Component
 public class SlackNotificationAspect {
 
     private final SlackApi slackApi;
+    private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
 
     @Around(
             value = "@annotation(com.twoclock.gitconnect.global.slack.annotation.SlackNotification) && args(request, e)",
@@ -31,13 +34,14 @@ public class SlackNotificationAspect {
     public Object slackNotification(
             ProceedingJoinPoint proceedingJoinPoint, HttpServletRequest request, Exception e
     ) throws Throwable {
-        Object proceed = proceedingJoinPoint.proceed();
-        sendSlackErrorMessage(request, e);
+        threadPoolTaskExecutor.execute(() -> sendSlackErrorMessage(request, e));
 
-        return proceed;
+        return proceedingJoinPoint.proceed();
     }
 
     private void sendSlackErrorMessage(HttpServletRequest request, Exception e) {
+        String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
+
         SlackAttachment slackAttachment = new SlackAttachment();
         slackAttachment.setFallback("Error");
         slackAttachment.setColor("danger");
@@ -49,7 +53,7 @@ public class SlackNotificationAspect {
                 Arrays.asList(
                         new SlackField().setTitle("Request URL").setValue(request.getRequestURL().toString()),
                         new SlackField().setTitle("Request Method").setValue(request.getMethod()),
-                        new SlackField().setTitle("Request Time").setValue(new Date().toString()),
+                        new SlackField().setTitle("Request Time").setValue(now),
                         new SlackField().setTitle("Request IP").setValue(request.getRemoteAddr()),
                         new SlackField().setTitle("Request User-Agent").setValue(request.getHeader("User-Agent"))
                 )
@@ -59,7 +63,7 @@ public class SlackNotificationAspect {
         slackMessage.setAttachments(Collections.singletonList(slackAttachment));
         slackMessage.setIcon(":x:");
         slackMessage.setText("에러가 발생했습니다.");
-        slackMessage.setUsername("에러봇");
+        slackMessage.setUsername("에러 봇");
         slackApi.call(slackMessage);
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/global/slack/aspect/SlackNotificationAspect.java
+++ b/src/main/java/com/twoclock/gitconnect/global/slack/aspect/SlackNotificationAspect.java
@@ -1,0 +1,65 @@
+package com.twoclock.gitconnect.global.slack.aspect;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import net.gpedro.integrations.slack.SlackApi;
+import net.gpedro.integrations.slack.SlackAttachment;
+import net.gpedro.integrations.slack.SlackField;
+import net.gpedro.integrations.slack.SlackMessage;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Profile(value = "local")
+@Aspect
+@Component
+public class SlackNotificationAspect {
+
+    private final SlackApi slackApi;
+
+    @Around(
+            value = "@annotation(com.twoclock.gitconnect.global.slack.annotation.SlackNotification) && args(request, e)",
+            argNames = "proceedingJoinPoint,request,e"
+    )
+    public Object slackNotification(
+            ProceedingJoinPoint proceedingJoinPoint, HttpServletRequest request, Exception e
+    ) throws Throwable {
+        Object proceed = proceedingJoinPoint.proceed();
+        sendSlackErrorMessage(request, e);
+
+        return proceed;
+    }
+
+    private void sendSlackErrorMessage(HttpServletRequest request, Exception e) {
+        SlackAttachment slackAttachment = new SlackAttachment();
+        slackAttachment.setFallback("Error");
+        slackAttachment.setColor("danger");
+        slackAttachment.setTitle("Error Log");
+        slackAttachment.setTitleLink(request.getContextPath());
+        slackAttachment.setText(Arrays.toString(e.getStackTrace()));
+        slackAttachment.setColor("danger");
+        slackAttachment.setFields(
+                Arrays.asList(
+                        new SlackField().setTitle("Request URL").setValue(request.getRequestURL().toString()),
+                        new SlackField().setTitle("Request Method").setValue(request.getMethod()),
+                        new SlackField().setTitle("Request Time").setValue(new Date().toString()),
+                        new SlackField().setTitle("Request IP").setValue(request.getRemoteAddr()),
+                        new SlackField().setTitle("Request User-Agent").setValue(request.getHeader("User-Agent"))
+                )
+        );
+
+        SlackMessage slackMessage = new SlackMessage();
+        slackMessage.setAttachments(Collections.singletonList(slackAttachment));
+        slackMessage.setIcon(":x:");
+        slackMessage.setText("에러가 발생했습니다.");
+        slackMessage.setUsername("에러봇");
+        slackApi.call(slackMessage);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

* #5 

## 변경 사항

* 에러 발생시 Slack 으로 알림이 전송됩니다.
* Aop를 활용하여 SlackNotification 어노테이션이 달린 메서드만 적용 됩니다. (현재는 handleException 에만 적용)
* Slack 에 요청을 보내고 응답을 기다리는 과정을 비동기로 처리하여 응답 시간을 대폭 단축시켰습니다. (268ms -> 87ms)

## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?
<img width="665" alt="스크린샷 2024-07-23 오전 1 28 15" src="https://github.com/user-attachments/assets/db49fd6c-3525-48d4-a218-a152cfc7617d">

## 참고 자료
https://shanepark.tistory.com/430

---

## 비동기 처리 전 
<img width="848" alt="스크린샷 2024-07-23 오전 1 08 17" src="https://github.com/user-attachments/assets/f9cff66d-4c7d-43a7-8d2a-ceadc9b8d26b">

## 비동기 처리 후
<img width="846" alt="스크린샷 2024-07-23 오전 1 15 58" src="https://github.com/user-attachments/assets/6678b86f-e262-4239-9b81-cb2268ecf5a9">

## 결과
응답 시간을 67.54% 단축 시켰습니다.