### PR TITLE
feat: 게시판 등록 API 생성

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardReqeustDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardReqeustDto.java
@@ -1,0 +1,17 @@
+package com.twoclock.gitconnect.domain.board.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class BoardReqeustDto {
+
+    public record BoardSaveReqDto(
+            @NotBlank(message = "제목을 입력해주세요.")
+            String title,
+            @NotBlank(message = "내용을 입력해주세요.")
+            String content,
+            @NotBlank(message = "카테고리는 필수값 입니다.")
+            String category
+    ) {
+
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardResponseDto.java
@@ -1,7 +1,31 @@
 package com.twoclock.gitconnect.domain.board.dto;
 
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.member.entity.Member;
+import lombok.Builder;
 
 public class BoardResponseDto {
+
+    @Builder
+    public record BoardRespDto(
+            Long id,
+            String title,
+            String content,
+            String nickname,
+            String category,
+            Member member
+    ) {
+        public BoardRespDto(Board board) {
+            this(
+                    board.getId(),
+                    board.getTitle(),
+                    board.getContent(),
+                    board.getNickname(),
+                    board.getCategory().name(),
+                    board.getMember()
+            );
+        }
+    }
 
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardResponseDto.java
@@ -1,0 +1,7 @@
+package com.twoclock.gitconnect.domain.board.dto;
+
+import com.twoclock.gitconnect.domain.member.entity.Member;
+
+public class BoardResponseDto {
+
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
@@ -9,11 +9,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.w3c.dom.Text;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE board SET is_view = false WHERE id = ?")
+@Where(clause = "is_view = true")
 public class Board extends BaseEntity {
 
     @Id

--- a/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
@@ -2,7 +2,6 @@ package com.twoclock.gitconnect.domain.board.entity;
 
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.member.entity.Member;
-import com.twoclock.gitconnect.domain.member.entity.constants.Role;
 import com.twoclock.gitconnect.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -11,7 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
-import org.w3c.dom.Text;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/src/main/java/com/twoclock/gitconnect/domain/board/entity/constants/Category.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/entity/constants/Category.java
@@ -1,8 +1,21 @@
 package com.twoclock.gitconnect.domain.board.entity.constants;
 
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+
 public enum Category {
 
     BD1, // 계정 홍보 게시글
     BD2, // Repository 홍보 게시글
-    BD3 // 신고 게시글
+    BD3; // 신고 게시글
+
+
+    // 카테고리 유효성 검사
+    public static Category of(String category) {
+        try {
+            return Category.valueOf(category);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.NOT_FOUND_CATEGORY);
+        }
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -1,19 +1,16 @@
 package com.twoclock.gitconnect.domain.board.service;
 
+import com.twoclock.gitconnect.domain.board.dto.BoardReqeustDto.BoardSaveReqDto;
+import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.BoardRespDto;
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
-import com.twoclock.gitconnect.domain.member.entity.constants.Role;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
-import com.twoclock.gitconnect.global.model.RestResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import com.twoclock.gitconnect.domain.board.dto.BoardReqeustDto.*;
-import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.*;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -4,6 +4,7 @@ import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.entity.constants.Role;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
@@ -31,6 +32,7 @@ public class BoardService {
         Board board = Board.builder()
                 .title(boardSaveReqDto.title())
                 .content(boardSaveReqDto.content())
+                .nickname(member.getNickname())
                 .category(code)
                 .member(member)
                 .build();

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -8,6 +8,7 @@ import com.twoclock.gitconnect.domain.member.entity.constants.Role;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import com.twoclock.gitconnect.global.model.RestResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -38,7 +39,7 @@ public class BoardService {
                 .build();
 
         boardRepository.save(board);
-        return ResponseEntity.ok().build();
+        return RestResponse.OK();
         // TODO : 성공 여부만 넘길 것인지, 생성 객체를 넘길 것인지 협의 필요
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -1,12 +1,42 @@
 package com.twoclock.gitconnect.domain.board.service;
 
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import com.twoclock.gitconnect.domain.board.dto.BoardReqeustDto.*;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class BoardService {
 
     private final BoardRepository boardRepository;
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public ResponseEntity<?> saveBoard(BoardSaveReqDto boardSaveReqDto, Long userId) {
+        Member member = memberRepository.findById(userId).orElseThrow(
+                ()-> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
+        );
+        Category code = Category.of(boardSaveReqDto.category());
+
+        Board board = Board.builder()
+                .title(boardSaveReqDto.title())
+                .content(boardSaveReqDto.content())
+                .category(code)
+                .member(member)
+                .build();
+
+        boardRepository.save(board);
+        return ResponseEntity.ok().build();
+        // TODO : 성공 여부만 넘길 것인지, 생성 객체를 넘길 것인지 협의 필요
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import com.twoclock.gitconnect.domain.board.dto.BoardReqeustDto.*;
+import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.*;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -24,7 +25,7 @@ public class BoardService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public ResponseEntity<?> saveBoard(BoardSaveReqDto boardSaveReqDto, Long userId) {
+    public BoardRespDto saveBoard(BoardSaveReqDto boardSaveReqDto, Long userId) {
         Member member = memberRepository.findById(userId).orElseThrow(
                 ()-> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
         );
@@ -37,9 +38,7 @@ public class BoardService {
                 .category(code)
                 .member(member)
                 .build();
-
-        boardRepository.save(board);
-        return RestResponse.OK();
-        // TODO : 성공 여부만 넘길 것인지, 생성 객체를 넘길 것인지 협의 필요
+        Board boardPS = boardRepository.save(board);
+        return new BoardRespDto(boardPS);
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -24,7 +24,7 @@ public class BoardController {
     public ResponseEntity<?> saveBoard(@RequestBody @Valid BoardSaveReqDto boardSaveReqDto,
                                        BindingResult bindingResult) throws BindException {
         // TODO : 로그인 유저인지 검증 필요
-        Long userId = 100L;
+        Long userId = 1L;
 
         // TODO : BindException 핸들링 필요
 

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -1,6 +1,5 @@
 package com.twoclock.gitconnect.domain.board.web;
 
-import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto;
 import com.twoclock.gitconnect.domain.board.service.BoardService;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.model.RestResponse;

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -23,9 +23,12 @@ public class BoardController {
     @PostMapping("")
     public ResponseEntity<?> saveBoard(@RequestBody @Valid BoardSaveReqDto boardSaveReqDto,
                                        BindingResult bindingResult) throws BindException {
+        // TODO : 로그인 유저인지 검증 필요
+        Long userId = 100L;
 
+        // TODO : BindException 핸들링 필요
 
-
-        return ResponseEntity.ok().build();
+        return  boardService.saveBoard(boardSaveReqDto, userId);
+        // TODO : 공통 ResponseDTO(코드, 상태값, 객체) 생성 필요
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -1,17 +1,18 @@
 package com.twoclock.gitconnect.domain.board.web;
 
-import com.twoclock.gitconnect.domain.board.dto.BoardReqeustDto;
+import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto;
 import com.twoclock.gitconnect.domain.board.service.BoardService;
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.model.RestResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindException;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.twoclock.gitconnect.domain.board.dto.BoardReqeustDto.*;
+import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.*;
+import static com.twoclock.gitconnect.global.exception.constants.ErrorCode.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/boards")
@@ -20,15 +21,15 @@ public class BoardController {
 
     private final BoardService boardService;
 
-    @PostMapping("")
-    public ResponseEntity<?> saveBoard(@RequestBody @Valid BoardSaveReqDto boardSaveReqDto,
-                                       BindingResult bindingResult) throws BindException {
+    @PostMapping
+    public RestResponse saveBoard(@RequestBody @Valid BoardSaveReqDto boardSaveReqDto){
         // TODO : 로그인 유저인지 검증 필요
         Long userId = 1L;
 
-        // TODO : BindException 핸들링 필요
+        BoardRespDto boardRespDto = boardService.saveBoard(boardSaveReqDto, userId);
+        if(boardRespDto == null) throw new CustomException(FAIL_SAVE_BOARD);
 
-        return  boardService.saveBoard(boardSaveReqDto, userId);
-        // TODO : 공통 ResponseDTO(코드, 상태값, 객체) 생성 필요
+        return RestResponse.OK();
+//        return new RestResponse(boardRespDto);
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -1,11 +1,31 @@
 package com.twoclock.gitconnect.domain.board.web;
 
+import com.twoclock.gitconnect.domain.board.dto.BoardReqeustDto;
+import com.twoclock.gitconnect.domain.board.service.BoardService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.twoclock.gitconnect.domain.board.dto.BoardReqeustDto.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/boards")
 @RestController
 public class BoardController {
+
+    private final BoardService boardService;
+
+    @PostMapping("")
+    public ResponseEntity<?> saveBoard(@RequestBody @Valid BoardSaveReqDto boardSaveReqDto,
+                                       BindingResult bindingResult) throws BindException {
+
+
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/entity/Comment.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/entity/Comment.java
@@ -8,10 +8,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE comment SET is_view = false WHERE id = ?")
+@Where(clause = "is_view = true")
 public class Comment extends BaseEntity {
 
     @Id

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -1,0 +1,32 @@
+package com.twoclock.gitconnect.global.dummy;
+
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.entity.constants.Role;
+import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Slf4j
+@Configuration
+public class DummyDevlnit {
+
+    // 프로덕트 출시 전에 개발자들이 사용할 더미 데이터를 초기화하는 클래스
+    @Profile("local")
+    @Bean
+    CommandLineRunner init(MemberRepository memberRepository) {
+        return (args) -> {
+            log.info("Dummy Data Init");
+            Member member = Member.builder()
+                    .nickname("테스트 유저")
+                    .token("testToken")
+                    .profileImageUrl("/uploads/profile/test.jpg")
+                    .role(Role.ROLE_USER)
+                    .build();
+            memberRepository.save(member);
+        };
+    }
+
+}

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
 
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "C-001", "찾을 수 없는 카테고리입니다."),
 
-    FAIL_SAVE_BOARD(HttpStatus.NOT_FOUND, "B-001", "게시글 저장에 실패하였습니다."),
+    FAIL_SAVE_BOARD(HttpStatus.INTERNAL_SERVER_ERROR, "B-001", "게시글 저장에 실패하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-001", "서버 에러가 발생했습니다."),
 
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "M-001", "찾을 수 없는 회원 계정입니다."),
+
+    NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "C-001", "찾을 수 없는 카테고리입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "M-001", "찾을 수 없는 회원 계정입니다."),
 
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "C-001", "찾을 수 없는 카테고리입니다."),
+
+    FAIL_SAVE_BOARD(HttpStatus.NOT_FOUND, "B-001", "게시글 저장에 실패하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/twoclock/gitconnect/global/model/HttpResponse.java
+++ b/src/main/java/com/twoclock/gitconnect/global/model/HttpResponse.java
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus;
 
 @Builder
 public record HttpResponse<T>(
-        HttpStatus httpStatus,
+        int httpStatus,
         String message,
         T data
 

--- a/src/main/java/com/twoclock/gitconnect/global/model/HttpResponse.java
+++ b/src/main/java/com/twoclock/gitconnect/global/model/HttpResponse.java
@@ -1,0 +1,23 @@
+package com.twoclock.gitconnect.global.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Rest API 응답을 위한 클래스
+ * 2XX httpStatus 성공 경우에만 반환
+ */
+
+@Builder
+public record HttpResponse<T>(
+        HttpStatus httpStatus,
+        String message,
+        T data
+
+) {
+
+
+}

--- a/src/main/java/com/twoclock/gitconnect/global/model/RestResponse.java
+++ b/src/main/java/com/twoclock/gitconnect/global/model/RestResponse.java
@@ -19,7 +19,7 @@ public class RestResponse extends ResponseEntity<HttpResponse<?>> {
     public static RestResponse OK() {
         // no data return
         HttpResponse<?> response = HttpResponse.builder()
-                .httpStatus(HttpStatus.OK)
+                .httpStatus(HttpStatus.OK.value())
                 .message(HttpStatus.OK.getReasonPhrase())
                 .build();
         return new RestResponse(response, HttpStatus.OK);
@@ -28,7 +28,7 @@ public class RestResponse extends ResponseEntity<HttpResponse<?>> {
     // 성공 응답 데이터 반환처리
     public RestResponse(Object resultData) {
         super(HttpResponse.builder()
-                .httpStatus(HttpStatus.OK)
+                .httpStatus(HttpStatus.OK.value())
                 .message("OK")
                 .data(resultData)
                 .build(), HttpStatus.OK);
@@ -37,7 +37,7 @@ public class RestResponse extends ResponseEntity<HttpResponse<?>> {
     // 성공 응답(헤더 반환처리)
     public RestResponse(Object resultData, HttpHeaders headers) {
         super(HttpResponse.builder()
-                .httpStatus(HttpStatus.OK)
+                .httpStatus(HttpStatus.OK.value())
                 .message("OK")
                 .data(resultData)
                 .build(), headers, HttpStatus.OK);

--- a/src/main/java/com/twoclock/gitconnect/global/model/RestResponse.java
+++ b/src/main/java/com/twoclock/gitconnect/global/model/RestResponse.java
@@ -19,7 +19,6 @@ public class RestResponse extends ResponseEntity<HttpResponse<?>> {
     public static RestResponse OK() {
         // no data return
         HttpResponse<?> response = HttpResponse.builder()
-                .httpStatus(HttpStatus.OK.value())
                 .message(HttpStatus.OK.getReasonPhrase())
                 .build();
         return new RestResponse(response, HttpStatus.OK);
@@ -28,7 +27,6 @@ public class RestResponse extends ResponseEntity<HttpResponse<?>> {
     // 성공 응답 데이터 반환처리
     public RestResponse(Object resultData) {
         super(HttpResponse.builder()
-                .httpStatus(HttpStatus.OK.value())
                 .message("OK")
                 .data(resultData)
                 .build(), HttpStatus.OK);
@@ -37,7 +35,6 @@ public class RestResponse extends ResponseEntity<HttpResponse<?>> {
     // 성공 응답(헤더 반환처리)
     public RestResponse(Object resultData, HttpHeaders headers) {
         super(HttpResponse.builder()
-                .httpStatus(HttpStatus.OK.value())
                 .message("OK")
                 .data(resultData)
                 .build(), headers, HttpStatus.OK);

--- a/src/main/java/com/twoclock/gitconnect/global/model/RestResponse.java
+++ b/src/main/java/com/twoclock/gitconnect/global/model/RestResponse.java
@@ -1,0 +1,50 @@
+package com.twoclock.gitconnect.global.model;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Rest API 응답을 위한 클래스
+ * 2XX httpStatus 성공 경우에만 반환
+ */
+public class RestResponse extends ResponseEntity<HttpResponse<?>> {
+
+    public RestResponse(HttpResponse body, HttpStatusCode status) {
+        super(body, status);
+    }
+
+    // 성공 응답(데이터 반환X)
+    public static RestResponse OK() {
+        // no data return
+        HttpResponse<?> response = HttpResponse.builder()
+                .httpStatus(HttpStatus.OK)
+                .message(HttpStatus.OK.getReasonPhrase())
+                .build();
+        return new RestResponse(response, HttpStatus.OK);
+    }
+
+    // 성공 응답 데이터 반환처리
+    public RestResponse(Object resultData) {
+        super(HttpResponse.builder()
+                .httpStatus(HttpStatus.OK)
+                .message("OK")
+                .data(resultData)
+                .build(), HttpStatus.OK);
+    }
+
+    // 성공 응답(헤더 반환처리)
+    public RestResponse(Object resultData, HttpHeaders headers) {
+        super(HttpResponse.builder()
+                .httpStatus(HttpStatus.OK)
+                .message("OK")
+                .data(resultData)
+                .build(), headers, HttpStatus.OK);
+    }
+
+
+
+
+
+}


### PR DESCRIPTION
## 관련 이슈

* #16 

## 변경 사항
* 프로젝트 Init 시점에서 Dummy User Data 등록 - 테스트 용도
* 게시판 등록 API 생성
* HttpResponse 공통 응답 객체 생성

---
> 게시판 등록 API 
**요청 주소 :  /api/v1/boards (post)**

> request
```
{
    "title" : "제목",
    "content" : "대충 내용",
    "category" : "BD1"
}
```

> response
```
{
    "httpStatus": 200,
    "message": "OK",
    "data": null
}
```

## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?
