### PR TITLE
feat: Add Delete Board API

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -54,4 +54,16 @@ public class BoardService {
 
         return new BoardRespDto(board);
     }
+
+    @Transactional
+    public void deleteBoard(Long boardKey, Long userId) {
+        Member member = memberRepository.findById(userId).orElseThrow(
+                ()-> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
+        );
+        Board board = boardRepository.findById(boardKey).orElseThrow(
+                ()-> new CustomException(ErrorCode.NOT_FOUND_BOARD)
+        );
+        board.checkUserId(member.getId());
+        boardRepository.delete(board);
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -39,4 +39,14 @@ public class BoardController {
 //        return new RestResponse(boardRespDto);
     }
 
+    @DeleteMapping("/{boardKey}")
+    public RestResponse deleteBoard(@PathVariable Long boardKey) {
+        // TODO : 로그인 유저인지 검증 필요
+        Long userId = 1L;
+
+        boardService.deleteBoard(boardKey, userId);
+
+        return RestResponse.OK();
+    }
+
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -40,7 +40,7 @@ public class BoardController {
     }
 
     @DeleteMapping("/{boardKey}")
-    public RestResponse deleteBoard(@PathVariable Long boardKey) {
+    public RestResponse deleteBoard(@PathVariable("boardKey") Long boardKey) {
         // TODO : 로그인 유저인지 검증 필요
         Long userId = 1L;
 


### PR DESCRIPTION
## 관련 이슈

* #17 

## 변경 사항

* 본인의 게시판 삭제 API(Soft Delete)

---
> 게시판 삭제 API
> 요청 주소 : /api/v1/boards/{boardKey} (delete)

> response
```
{
    "message": "OK",
    "data": null
}
```
![image](https://github.com/user-attachments/assets/765bb21e-0d27-4da1-8999-68bd9ff6f9a9)

* Soft Delete 이후 isView 컬럼에 대한 값이 `FALSE` 로 변경 확인 


## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?