### PR TITLE
feat: Add Redis Integration and JWT Token Refresh Functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     // Database
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Slack-Api
     implementation 'net.gpedro.integrations.slack:slack-webhook:1.4.0'

--- a/src/main/java/com/twoclock/gitconnect/domain/member/web/MemberAuthController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/web/MemberAuthController.java
@@ -5,10 +5,7 @@ import com.twoclock.gitconnect.domain.member.service.MemberAuthService;
 import com.twoclock.gitconnect.global.model.RestResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members/auth")
@@ -21,5 +18,14 @@ public class MemberAuthController {
     public RestResponse githubLogin(@RequestParam String code, HttpServletResponse httpServletResponse) {
         MemberInfoDto responseDto = memberAuthService.githubLogin(code, httpServletResponse);
         return new RestResponse(responseDto);
+    }
+
+    @PostMapping("/refresh")
+    public RestResponse refreshJwtToken(
+            @CookieValue(name = "refreshToken") String refreshToken,
+            HttpServletResponse httpServletResponse
+    ) {
+        memberAuthService.refreshJwtToken(refreshToken, httpServletResponse);
+        return RestResponse.OK();
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/global/config/RedisConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.twoclock.gitconnect.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
@@ -30,6 +30,9 @@ public class WebSecurityConfig {
     private static final String[] GET_PERMIT_STRINGS = {
             "/api/v1/members/auth/github/callback"
     };
+    private static final String[] POST_PERMIT_STRINGS = {
+            "/api/v1/members/auth/refresh"
+    };
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
@@ -65,6 +68,7 @@ public class WebSecurityConfig {
 
         http.authorizeHttpRequests((requests) -> requests
                         .requestMatchers(HttpMethod.GET, GET_PERMIT_STRINGS).permitAll()
+                        .requestMatchers(HttpMethod.POST, POST_PERMIT_STRINGS).permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-001", "서버 에러가 발생했습니다."),
 
     JWT_ERROR(HttpStatus.UNAUTHORIZED, "JWT-001", "JWT 토큰 에러가 발생했습니다."),
+    JWT_REFRESH_TOKEN_ERROR(HttpStatus.FORBIDDEN, "JWT-002", "JWT 리프레쉬 토큰 에러가 발생했습니다."),
 
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "M-001", "찾을 수 없는 회원 계정입니다."),
     DIFF_USER_BOARD(HttpStatus.FORBIDDEN, "M-002", "게시글을 등록한 사용자와 일치하지 않습니다."),

--- a/src/main/java/com/twoclock/gitconnect/global/jwt/JwtService.java
+++ b/src/main/java/com/twoclock/gitconnect/global/jwt/JwtService.java
@@ -14,18 +14,16 @@ import java.util.Date;
 public class JwtService {
 
     private static final int ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000; // 30분
+    public static final int REFRESH_TOKEN_EXPIRATION_TIME = 7 * 24 * 60 * 60 * 1000; // 일주일
+
     private static final SecretKey SECRET_KEY = Jwts.SIG.HS256.key().build();
     public static final String BEARER_PREFIX = "Bearer ";
 
     public String generateAccessToken(Member member) {
-        return generateToken(member.getLogin(), member.getAvatarUrl(), member.getName());
-    }
+        String subject = member.getLogin();
+        String avatarUrl = member.getAvatarUrl();
+        String name = member.getName();
 
-    public String getLogin(String accessToken) {
-        return getSubject(accessToken);
-    }
-
-    private String generateToken(String subject, String avatarUrl, String name) {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION_TIME);
 
@@ -37,6 +35,24 @@ public class JwtService {
                 .issuedAt(now)
                 .expiration(expiration)
                 .compact();
+    }
+
+    public String generateRefreshToken(Member member) {
+        String subject = member.getLogin();
+
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME);
+
+        return Jwts.builder()
+                .subject(subject)
+                .signWith(SECRET_KEY)
+                .issuedAt(now)
+                .expiration(expiration)
+                .compact();
+    }
+
+    public String getLogin(String jwtToken) {
+        return getSubject(jwtToken);
     }
 
     private String getSubject(String token) {

--- a/src/main/java/com/twoclock/gitconnect/global/jwt/dto/JwtTokenInfoDto.java
+++ b/src/main/java/com/twoclock/gitconnect/global/jwt/dto/JwtTokenInfoDto.java
@@ -1,0 +1,7 @@
+package com.twoclock.gitconnect.global.jwt.dto;
+
+public record JwtTokenInfoDto(
+        String accessToken,
+        String refreshToken
+) {
+}


### PR DESCRIPTION
## 관련 이슈

* #25 

## 변경 사항

- 로그인 시 Refresh Token 이 발급됩니다. (일주일) 
  - 발급된 Refresh Token 은 Redis 와 Cookie 에 저장됩니다.
    - Redis 에는 ``Key: GitHub ID, Value: Refresh Token`` 으로 저장됩니다.
- ``/api/v1/members/auth/refresh`` 엔드포인트로 POST 요청을 보낼 시 새로운 JWT 토큰이 발급됩니다.
  1. 정상적인 JWT 토큰인지 검증합니다.
  2. 정상적인 JWT 토큰이라면 Cookie 에 저장된 Refresh Token 에서 GitHub ID 를 추출합니다.
  3. 추출한 GitHub ID가 Redis 에 저장되어 있는지 확인합니다.
  4. Redis 에 저장된 GitHub ID 라면 새로운 Access Token 과 Refresh Token 을 발급합니다.
     - Redis 에 새로 발행된 Refresh Token 으로 값이 갱신 되기 때문에 기존 Refresh Token 은 사용할 수 없게 됩니다. (3번에 걸리게 됨)
     
#### application.yml (Redis 관련 설정)
```yml
spring:
  data:
    redis:
      port: 6379
      host: localhost
```
     
#### 쿠키 저장
<img width="650" alt="스크린샷 2024-08-10 오후 9 02 07" src="https://github.com/user-attachments/assets/e8339f1f-1d8b-4cfa-96d0-c811480a8ec7">

#### 레디스 저장 (새로운 Refresh Token 재발급)
<img width="932" alt="스크린샷 2024-08-10 오후 9 03 01" src="https://github.com/user-attachments/assets/95a65bfe-2da6-4ebc-82de-044bbc0fd1bd">

## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?

## 리뷰 요청
@jjangsky 님~ 여름이 얼른 끝났으면 좋겠네요.. 🥵
로그인 관련해서 Refresh Token 발급과 재발급 기능을 추가했습니다.
확인 부탁드리겠습니다 ~