### PR TITLE
feat: Creating a bulletin board API using Querydsl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,12 @@ dependencies {
 
     // Slack-Api
     implementation 'net.gpedro.integrations.slack:slack-webhook:1.4.0'
+
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor"com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardRequestDto.java
@@ -30,4 +30,5 @@ public class BoardRequestDto {
     ) {
 
     }
+
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardResponseDto.java
@@ -1,8 +1,6 @@
 package com.twoclock.gitconnect.domain.board.dto;
 
-import com.querydsl.core.annotations.QueryProjection;
 import com.twoclock.gitconnect.domain.board.entity.Board;
-import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import lombok.Builder;
 

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardResponseDto.java
@@ -1,5 +1,6 @@
 package com.twoclock.gitconnect.domain.board.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.member.entity.Member;
@@ -26,6 +27,7 @@ public class BoardResponseDto {
                     board.getMember()
             );
         }
+
     }
 
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchRequestDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchRequestDto.java
@@ -1,0 +1,22 @@
+package com.twoclock.gitconnect.domain.board.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.domain.PageRequest;
+
+public record SearchRequestDto(
+        String searchWord,
+        String searchType, // 검색 조건(제목, 내용, 작성자)
+        @NotBlank(message = "카테고리는 필수값 입니다.")
+        String category,
+        Long page,
+        Long size
+
+) {
+    public PageRequest toPageRequest() {
+        int pageNumber = (page != null) ? page.intValue() : 0;
+        int pageSize = (size != null) ? size.intValue() : 10;
+        return PageRequest.of(pageNumber, pageSize);
+    }
+
+}
+

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchRequestDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchRequestDto.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.domain.PageRequest;
 
 public record SearchRequestDto(
-        String searchWord,
-        String searchType, // 검색 조건(제목, 내용, 작성자)
+        String word,
+        String type, // 검색 조건(제목, 내용, 작성자)
         @NotBlank(message = "카테고리는 필수값 입니다.")
         String category,
         Long page,

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchResponseDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchResponseDto.java
@@ -1,9 +1,7 @@
 package com.twoclock.gitconnect.domain.board.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.member.dto.MemberInfoDto;
-import com.twoclock.gitconnect.domain.member.entity.Member;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchResponseDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchResponseDto.java
@@ -2,6 +2,7 @@ package com.twoclock.gitconnect.domain.board.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.member.dto.MemberInfoDto;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import lombok.Builder;
 
@@ -12,11 +13,11 @@ public record SearchResponseDto(
         String content,
         String nickname,
         String category,
-        Member member
+        MemberInfoDto member
 ) {
 
     @QueryProjection
-    public SearchResponseDto(Long id, String title, String content, String nickname, String category, Member member) {
+    public SearchResponseDto(Long id, String title, String content, String nickname, String category, MemberInfoDto member) {
         this.id = id;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchResponseDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchResponseDto.java
@@ -1,0 +1,29 @@
+package com.twoclock.gitconnect.domain.board.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record SearchResponseDto(
+        Long id,
+        String title,
+        String content,
+        String nickname,
+        String category,
+        Member member
+) {
+
+    @QueryProjection
+    public SearchResponseDto(Long id, String title, String content, String nickname, String category, Member member) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.nickname = nickname;
+        this.category = category;
+        this.member = member;
+    }
+}
+
+

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepository.java
@@ -2,6 +2,9 @@ package com.twoclock.gitconnect.domain.board.repository;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, Long> ,
+        CustomBoardRepository ,
+        QuerydslPredicateExecutor<Board> {
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
@@ -18,7 +18,7 @@ import java.util.List;
 import static com.twoclock.gitconnect.domain.board.entity.QBoard.board;
 import static com.twoclock.gitconnect.domain.member.entity.QMember.member;
 
-public class BoardRepositoryImpl implements CustomBoardRepository{
+public class BoardRepositoryImpl implements CustomBoardRepository {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
@@ -7,13 +7,13 @@ import com.twoclock.gitconnect.domain.board.dto.QSearchResponseDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
+import com.twoclock.gitconnect.domain.member.dto.QMemberInfoDto;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-import java.util.function.Predicate;
 
 import static com.twoclock.gitconnect.domain.board.entity.QBoard.board;
 import static com.twoclock.gitconnect.domain.member.entity.QMember.member;
@@ -35,7 +35,7 @@ public class BoardRepositoryImpl implements CustomBoardRepository{
                         board.content,
                         board.nickname,
                         board.category.stringValue(),
-                        board.member
+                        new QMemberInfoDto(board.member.login, board.member.avatarUrl, board.member.name)
                 ))
                 .from(board)
                 .join(board.member, member)

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
@@ -1,16 +1,19 @@
 package com.twoclock.gitconnect.domain.board.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.twoclock.gitconnect.domain.board.dto.QSearchResponseDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
+import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import static com.twoclock.gitconnect.domain.board.entity.QBoard.board;
 import static com.twoclock.gitconnect.domain.member.entity.QMember.member;
@@ -35,7 +38,9 @@ public class BoardRepositoryImpl implements CustomBoardRepository{
                         board.member
                 ))
                 .from(board)
-                .join(board.member, member)
+                .join(board.member, member).fetchJoin()
+                .where(searchQueryBuilder(searchRequestDto))
+                .orderBy(board.createdDateTime.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetchResults();
@@ -44,4 +49,37 @@ public class BoardRepositoryImpl implements CustomBoardRepository{
 
         return new PageImpl<>(content, pageable, total);
     }
+
+    private BooleanBuilder searchQueryBuilder(SearchRequestDto searchRequestDto) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 게시판 카테고리 설정
+        builder.and(board.category.eq(Category.valueOf(searchRequestDto.category())));
+
+        // 검색어가 존재하는 경우
+        if(searchRequestDto.searchWord() != null) {
+            switch (searchRequestDto.searchType()) {
+                case "title":
+                    builder.and(board.title.contains(searchRequestDto.searchWord()));
+                    break;
+                case "content":
+                    builder.and(board.content.contains(searchRequestDto.searchWord()));
+                    break;
+                case "name":
+                    builder.and(board.nickname.contains(searchRequestDto.searchWord()));
+                    break;
+                case "all":
+                    builder.and(
+                            board.title.contains(searchRequestDto.searchWord())
+                                    .or(board.content.contains(searchRequestDto.searchWord()))
+                                    .or(board.nickname.contains(searchRequestDto.searchWord()))
+                    );
+                    break;
+            }
+        }
+
+        return builder;
+    }
+
+
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
@@ -57,22 +57,22 @@ public class BoardRepositoryImpl implements CustomBoardRepository{
         builder.and(board.category.eq(Category.of(searchRequestDto.category())));
 
         // 검색어가 존재하는 경우
-        if(searchRequestDto.searchWord() != null) {
-            switch (searchRequestDto.searchType()) {
+        if(searchRequestDto.word() != null) {
+            switch (searchRequestDto.type()) {
                 case "title":
-                    builder.and(board.title.contains(searchRequestDto.searchWord()));
+                    builder.and(board.title.contains(searchRequestDto.word()));
                     break;
                 case "content":
-                    builder.and(board.content.contains(searchRequestDto.searchWord()));
+                    builder.and(board.content.contains(searchRequestDto.word()));
                     break;
                 case "name":
-                    builder.and(board.nickname.contains(searchRequestDto.searchWord()));
+                    builder.and(board.nickname.contains(searchRequestDto.word()));
                     break;
                 case "all":
                     builder.and(
-                            board.title.contains(searchRequestDto.searchWord())
-                                    .or(board.content.contains(searchRequestDto.searchWord()))
-                                    .or(board.nickname.contains(searchRequestDto.searchWord()))
+                            board.title.contains(searchRequestDto.word())
+                                    .or(board.content.contains(searchRequestDto.word()))
+                                    .or(board.nickname.contains(searchRequestDto.word()))
                     );
                     break;
             }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
@@ -38,7 +38,7 @@ public class BoardRepositoryImpl implements CustomBoardRepository{
                         board.member
                 ))
                 .from(board)
-                .join(board.member, member).fetchJoin()
+                .join(board.member, member)
                 .where(searchQueryBuilder(searchRequestDto))
                 .orderBy(board.createdDateTime.desc())
                 .offset(pageable.getOffset())
@@ -54,7 +54,7 @@ public class BoardRepositoryImpl implements CustomBoardRepository{
         BooleanBuilder builder = new BooleanBuilder();
 
         // 게시판 카테고리 설정
-        builder.and(board.category.eq(Category.valueOf(searchRequestDto.category())));
+        builder.and(board.category.eq(Category.of(searchRequestDto.category())));
 
         // 검색어가 존재하는 경우
         if(searchRequestDto.searchWord() != null) {

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.twoclock.gitconnect.domain.board.repository;
+
+import com.querydsl.core.QueryResults;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twoclock.gitconnect.domain.board.dto.QSearchResponseDto;
+import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
+import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.twoclock.gitconnect.domain.board.entity.QBoard.board;
+import static com.twoclock.gitconnect.domain.member.entity.QMember.member;
+
+public class BoardRepositoryImpl implements CustomBoardRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    public BoardRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<SearchResponseDto> searchBoardList(SearchRequestDto searchRequestDto, Pageable pageable) {
+        QueryResults<SearchResponseDto> result = queryFactory
+                .select(new QSearchResponseDto(
+                        board.id,
+                        board.title,
+                        board.content,
+                        board.nickname,
+                        board.category.stringValue(),
+                        board.member
+                ))
+                .from(board)
+                .join(board.member, member)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchResults();
+        List<SearchResponseDto> content = result.getResults();
+        long total = result.getTotal();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/CustomBoardRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/CustomBoardRepository.java
@@ -1,0 +1,12 @@
+package com.twoclock.gitconnect.domain.board.repository;
+
+
+import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
+import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomBoardRepository {
+    Page<SearchResponseDto> searchBoardList(SearchRequestDto searchRequestDto, Pageable pageRequest);
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/CustomBoardRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/CustomBoardRepository.java
@@ -4,7 +4,6 @@ package com.twoclock.gitconnect.domain.board.repository;
 import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomBoardRepository {

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -62,6 +62,12 @@ public class BoardService {
     @Transactional(readOnly = true)
     public Page<SearchResponseDto> getBoardList(SearchRequestDto searchRequestDto) {
 
+        // TODO: 카테고리 타입 확인
+
+        // TODO: 신고 게시판 정책 추가
+
+        //
+
         // 페이지 요청 객체 생성
         PageRequest pageRequest = searchRequestDto.toPageRequest();
 

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -2,6 +2,8 @@ package com.twoclock.gitconnect.domain.board.service;
 
 import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.*;
 import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.*;
+import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
+import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
@@ -10,6 +12,8 @@ import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,5 +57,16 @@ public class BoardService {
         board.updateBoard(boardUpdateReqDto.title(), boardUpdateReqDto.content());
 
         return new BoardRespDto(board);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<SearchResponseDto> getBoardList(SearchRequestDto searchRequestDto) {
+
+        // 페이지 요청 객체 생성
+        PageRequest pageRequest = searchRequestDto.toPageRequest();
+
+        Page<SearchResponseDto> boardList = boardRepository.searchBoardList(searchRequestDto, pageRequest);
+
+        return boardList;
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -76,6 +76,8 @@ public class BoardService {
 
         return boardList;
 
+    }
+
     @Transactional
     public void deleteBoard(Long boardKey, Long userId) {
         Member member = memberRepository.findById(userId).orElseThrow(

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -1,7 +1,8 @@
 package com.twoclock.gitconnect.domain.board.service;
 
-import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.*;
-import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.*;
+import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.BoardModifyReqDto;
+import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.BoardSaveReqDto;
+import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.BoardRespDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
 import com.twoclock.gitconnect.domain.board.entity.Board;

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -1,14 +1,15 @@
 package com.twoclock.gitconnect.domain.board.web;
 
+import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
+import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
 import com.twoclock.gitconnect.domain.board.service.BoardService;
-import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.model.RestResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.*;
 import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.*;
-import static com.twoclock.gitconnect.global.exception.constants.ErrorCode.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/boards")
@@ -37,6 +38,14 @@ public class BoardController {
 
         return RestResponse.OK();
 //        return new RestResponse(boardRespDto);
+    }
+
+    @GetMapping
+    public RestResponse getBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto) {
+
+        Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto);
+
+        return RestResponse.OK();
     }
 
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -45,7 +45,7 @@ public class BoardController {
 
         Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto);
 
-        return RestResponse.OK();
+        return new RestResponse(boardRespDto);
     }
 
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -1,5 +1,8 @@
 package com.twoclock.gitconnect.domain.board.web;
 
+import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.BoardModifyReqDto;
+import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.BoardSaveReqDto;
+import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.BoardRespDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
 import com.twoclock.gitconnect.domain.board.service.BoardService;
@@ -8,8 +11,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
-import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.*;
-import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/boards")

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -48,6 +48,8 @@ public class BoardController {
 
         return new RestResponse(boardRespDto);
 
+    }
+
     @DeleteMapping("/{boardKey}")
     public RestResponse deleteBoard(@PathVariable("boardKey") Long boardKey) {
         // TODO : 로그인 유저인지 검증 필요

--- a/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberInfoDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberInfoDto.java
@@ -1,9 +1,18 @@
 package com.twoclock.gitconnect.domain.member.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
+
 public record MemberInfoDto(
         String login,
         String avatarUrl,
         String name
 ) {
+
+    @QueryProjection
+    public MemberInfoDto(String login, String avatarUrl, String name) {
+        this.login = login;
+        this.avatarUrl = avatarUrl;
+        this.name = name;
+    }
 
 }

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -45,7 +45,7 @@ public class DummyDevlnit {
     }
 
     private void createDummyBoards(List<Board> boards, String titlePrefix, Category category,
-                                   int count, Member member){
+                                   int count, Member member) {
         for (int i = 0; i < count; i++) {
             Board board = Board.builder()
                     .title(titlePrefix + i)

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -1,5 +1,8 @@
 package com.twoclock.gitconnect.global.dummy;
 
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.board.entity.constants.Category;
+import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.entity.constants.Role;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
@@ -9,6 +12,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Slf4j
 @Configuration
 public class DummyDevlnit {
@@ -16,19 +22,40 @@ public class DummyDevlnit {
     // 프로덕트 출시 전에 개발자들이 사용할 더미 데이터를 초기화하는 클래스
     @Profile("local")
     @Bean
-    CommandLineRunner init(MemberRepository memberRepository) {
+    CommandLineRunner init(MemberRepository memberRepository, BoardRepository boardRepository) {
         return (args) -> {
             log.info("Dummy Data Init");
 
+            // 테스트 계정 생성
             Member member = Member.builder()
                     .login("loginId")
                     .avatarUrl("/uploads/profile/test.jpg")
                     .name("테스트 유저")
                     .role(Role.ROLE_USER)
                     .build();
-
             memberRepository.save(member);
+
+            // 테스트 게시글 생성
+            List<Board> boards = new ArrayList<>();
+            createDummyBoards(boards, "계정 홍보 테스트 게시글", Category.BD1, 10, member);
+            createDummyBoards(boards, "저장소 홍보 테스트 게시글", Category.BD2, 10, member);
+            createDummyBoards(boards, "사용자 신고 테스트 게시글", Category.BD3, 10, member);
+            boardRepository.saveAll(boards);
         };
+    }
+
+    private void createDummyBoards(List<Board> boards, String titlePrefix, Category category,
+                                   int count, Member member){
+        for (int i = 0; i < count; i++) {
+            Board board = Board.builder()
+                    .title(titlePrefix + i)
+                    .content("테스트 게시글 내용" + i)
+                    .nickname("테스트 유저")
+                    .member(member)
+                    .category(category)
+                    .build();
+            boards.add(board);
+        }
     }
 
 }


### PR DESCRIPTION
## 관련 이슈

* #14 

## 변경 사항

> 계정 홍보, 저장소 홍보, 신고 게시판 조회 API 생성

주소 : `/api/v1/boards`

**RequestParam**
 - word(검색 입력값)
 - type(검색 조건)
 - category(게시판 종류, 필수값)
 - page(현재 페이지, Defualt = 1)
 - size(한번에 조회할 수량, Default =10)

> ex: 제목중에 '테스트' 라는 단어가 포함된 계정 홍보 게시글
> http://localhost:8082/api/v1/boards?searchWord=테스트&searchType=title&category=BD1

**Response**
```
{
    "message": "OK",
    "data": {
        "totalPages": 1,
        "totalElements": 10,
        "size": 10,
        "content": [
            {
                "id": 9,
                "title": "계정 홍보 테스트 게시글8",
                "content": "테스트 게시글 내용8",
                "nickname": "테스트 유저",
                "category": "BD1",
                "member": {
                    "createdDateTime": "2024-08-11T20:47:43.543585",
                    "modifiedDateTime": null,
                    "id": 1,
                    "login": "loginId",
                    "avatarUrl": "/uploads/profile/test.jpg",
                    "name": "테스트 유저",
                    "role": "ROLE_USER"
                }
            },
            {
                "id": 10,
                "title": "계정 홍보 테스트 게시글9",
                "content": "테스트 게시글 내용9",
                "nickname": "테스트 유저",
                "category": "BD1",
                "member": {
                    "createdDateTime": "2024-08-11T20:47:43.543585",
                    "modifiedDateTime": null,
                    "id": 1,
                    "login": "loginId",
                    "avatarUrl": "/uploads/profile/test.jpg",
                    "name": "테스트 유저",
                    "role": "ROLE_USER"
                }
            },
           {...},
           {...}
     }
}

```

조회 API를 만들기는 했으나 게시글의 노출 방식이나 관련 정책에 따라 몇차례 수정될 것 같습니다.




## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?
