### PR TITLE
feat: GolbalException add 4XX error 

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/GlobalExceptionHandler.java
@@ -7,8 +7,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -38,4 +41,48 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(responseDto, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponseDto> MethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        ErrorResponseDto responseDto =
+                new ErrorResponseDto(
+                        ErrorCode.BAD_REQUEST.getCode(),
+                        ErrorCode.BAD_REQUEST.getMessage(),
+                        null
+                );
+
+        log.error(e.getMessage(), e);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponseDto> AccessDeniedException(AccessDeniedException e) {
+        ErrorResponseDto responseDto =
+                new ErrorResponseDto(
+                        ErrorCode.BAD_REQUEST.getCode(),
+                        ErrorCode.BAD_REQUEST.getMessage(),
+                        null
+                );
+
+        log.error(e.getMessage(), e);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ErrorResponseDto> MissingRequestCookieException(MissingRequestCookieException e) {
+        ErrorResponseDto responseDto =
+                new ErrorResponseDto(
+                        ErrorCode.NOT_ACCEPTABLE.getCode(),
+                        ErrorCode.NOT_ACCEPTABLE.getMessage(),
+                        null
+                );
+
+        log.error(e.getMessage(), e);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+
 }

--- a/src/main/java/com/twoclock/gitconnect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/GlobalExceptionHandler.java
@@ -5,19 +5,19 @@ import com.twoclock.gitconnect.global.slack.annotation.SlackNotification;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -93,16 +93,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDto> MethodArgumentNotValidException(MethodArgumentNotValidException e) {
         BindingResult bindingResult = e.getBindingResult();
-        List<String> errorMessages = bindingResult.getAllErrors().stream()
-                .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                .toList();
-        String errorMessage = String.join(", ", errorMessages);
+        Map<String, String> errorMap = new HashMap<>();
+        for (FieldError error : bindingResult.getFieldErrors()) {
+            errorMap.put(error.getField(), error.getDefaultMessage());
+        }
 
         ErrorResponseDto responseDto =
                 new ErrorResponseDto(
                         ErrorCode.BAD_REQUEST.getCode(),
-                        errorMessage,
-                        null
+                        "유효성 검사 실패",
+                        errorMap
                 );
 
         log.error(e.getMessage(), e);

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -10,6 +10,9 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-001", "서버 에러가 발생했습니다."),
 
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "U-001", "잘못된 요청입니다."),
+    NOT_ACCEPTABLE(HttpStatus.NOT_ACCEPTABLE, "U-002", "요청을 수락할 수 없습니다."),
+
     JWT_ERROR(HttpStatus.UNAUTHORIZED, "JWT-001", "JWT 토큰 에러가 발생했습니다."),
     JWT_REFRESH_TOKEN_ERROR(HttpStatus.FORBIDDEN, "JWT-002", "JWT 리프레쉬 토큰 에러가 발생했습니다."),
 


### PR DESCRIPTION
## 관련 이슈

* #21 

## 변경 사항
> 전역 예외처리 추가
-  `MethodArgumentTypeMismatchException`
-  `AccessDeniedException`
-  `MissingRequestCookieException`
-  `MethodArgumentNotValidException`

-> 해당 Exception 들은 Client 측 오류로 생각하여 `@SlackNotification`을 부여하지는 않았습니다.

> 게시판 등록 API 실행 시, 제목을 입력 안한 경우
![image](https://github.com/user-attachments/assets/a2bb9654-d1c7-4eca-8b35-678607a75e94)
잘못된 Request를 전송할 경우 설정한 Default Message가 발송되는 것 확인하였습니다.



## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?