### PR TITLE
feat: Add GitHub ID to Member Entity, S3 Configuration, and Avatar Upload Feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     // Querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor"com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 
@@ -66,6 +66,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // Aws s3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.741'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
@@ -35,7 +35,7 @@ public class BoardRepositoryImpl implements CustomBoardRepository {
                         board.content,
                         board.nickname,
                         board.category.stringValue(),
-                        new QMemberInfoDto(board.member.login, board.member.avatarUrl, board.member.name)
+                        new QMemberInfoDto(board.member.login, board.member.gitHubId, board.member.avatarUrl, board.member.name)
                 ))
                 .from(board)
                 .join(board.member, member)
@@ -57,7 +57,7 @@ public class BoardRepositoryImpl implements CustomBoardRepository {
         builder.and(board.category.eq(Category.of(searchRequestDto.category())));
 
         // 검색어가 존재하는 경우
-        if(searchRequestDto.word() != null) {
+        if (searchRequestDto.word() != null) {
             switch (searchRequestDto.type()) {
                 case "title":
                     builder.and(board.title.contains(searchRequestDto.word()));

--- a/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberInfoDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberInfoDto.java
@@ -4,13 +4,15 @@ import com.querydsl.core.annotations.QueryProjection;
 
 public record MemberInfoDto(
         String login,
+        String gitHubId,
         String avatarUrl,
         String name
 ) {
 
     @QueryProjection
-    public MemberInfoDto(String login, String avatarUrl, String name) {
+    public MemberInfoDto(String login, String gitHubId, String avatarUrl, String name) {
         this.login = login;
+        this.gitHubId = gitHubId;
         this.avatarUrl = avatarUrl;
         this.name = name;
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberRequestDto.java
@@ -1,0 +1,15 @@
+package com.twoclock.gitconnect.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class MemberRequestDto {
+
+    public record MemberModifyReqDto(
+            @NotBlank(message = "아이디를 입력해주시길 바랍니다.")
+            String login,
+
+            @NotBlank(message = "이름을 입력해주시길 바랍니다.")
+            String name
+    ) {
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberRequestDto.java
@@ -1,14 +1,9 @@
 package com.twoclock.gitconnect.domain.member.dto;
 
-import jakarta.validation.constraints.NotBlank;
-
 public class MemberRequestDto {
 
     public record MemberModifyReqDto(
-            @NotBlank(message = "아이디를 입력해주시길 바랍니다.")
             String login,
-
-            @NotBlank(message = "이름을 입력해주시길 바랍니다.")
             String name
     ) {
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberResponseDto.java
@@ -1,0 +1,11 @@
+package com.twoclock.gitconnect.domain.member.dto;
+
+public class MemberResponseDto {
+
+    public record MemberModifyRespDto(
+            String login,
+            String avatarUrl,
+            String name
+    ) {
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/member/entity/Member.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/entity/Member.java
@@ -20,6 +20,9 @@ public class Member extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String login;
 
+    @Column(nullable = false, unique = true)
+    private String gitHubId;
+
     @Column(nullable = false)
     private String avatarUrl;
 
@@ -31,8 +34,9 @@ public class Member extends BaseEntity {
     private Role role;
 
     @Builder
-    public Member(String login, String avatarUrl, String name, Role role) {
+    public Member(String login, String gitHubId, String avatarUrl, String name, Role role) {
         this.login = login;
+        this.gitHubId = gitHubId;
         this.avatarUrl = avatarUrl;
         this.name = name;
         this.role = role;

--- a/src/main/java/com/twoclock/gitconnect/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/repository/MemberRepository.java
@@ -7,5 +7,9 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByGitHubId(String githubId);
+
     Optional<Member> findByLogin(String login);
+
+    boolean existsByLogin(String login);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberService.java
@@ -1,12 +1,84 @@
 package com.twoclock.gitconnect.domain.member.service;
 
+import com.twoclock.gitconnect.domain.member.dto.MemberRequestDto.MemberModifyReqDto;
+import com.twoclock.gitconnect.domain.member.dto.MemberResponseDto.MemberModifyRespDto;
+import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import com.twoclock.gitconnect.global.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class MemberService {
 
+    private static final int MAX_AVATAR_IMAGE_SIZE = 5 * 1024 * 1024;
+    private static final List<String> PERMIT_AVATAR_IMAGE_TYPE = List.of(
+            "image/jpeg", "image/jpg", "image/png"
+    );
+
     private final MemberRepository memberRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public MemberModifyRespDto modify(String gitHubId, MemberModifyReqDto requestDto, MultipartFile multipartFile) {
+        Member member = memberRepository.findByGitHubId(gitHubId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+
+        if (memberRepository.existsByLogin(requestDto.login())) {
+            throw new CustomException(ErrorCode.ALREADY_EXIST_MEMBER);
+        }
+
+        String avatarImageUrl = member.getAvatarUrl();
+        if (!multipartFile.isEmpty()) {
+            String avatarImageKey = extractKeyFromUrl(member.getAvatarUrl());
+            s3Service.deleteFile(avatarImageKey);
+            avatarImageUrl = handleAvatarImage(multipartFile);
+        }
+
+        member.update(requestDto.login(), avatarImageUrl, requestDto.name());
+        return new MemberModifyRespDto(member.getLogin(), avatarImageUrl, member.getName());
+    }
+
+    private String handleAvatarImage(MultipartFile multipartFile) {
+        if (multipartFile.getSize() > MAX_AVATAR_IMAGE_SIZE) {
+            throw new CustomException(ErrorCode.OVER_AVATAR_IMAGE_SIZE);
+        }
+
+        if (!PERMIT_AVATAR_IMAGE_TYPE.contains(multipartFile.getContentType())) {
+            throw new CustomException(ErrorCode.INVALID_AVATAR_IMAGE_TYPE);
+        }
+
+        String originalFilename = multipartFile.getOriginalFilename();
+        String extension = Objects.requireNonNull(originalFilename).substring(originalFilename.lastIndexOf("."));
+        String randomImageUrl = UUID.randomUUID() + extension;
+
+        try {
+            return s3Service.uploadFile(randomImageUrl, multipartFile);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String extractKeyFromUrl(String fileUrl) {
+        try {
+            URL url = new URL(fileUrl);
+            return url.getPath().substring(1);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/member/web/MemberController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/web/MemberController.java
@@ -1,11 +1,35 @@
 package com.twoclock.gitconnect.domain.member.web;
 
+import com.twoclock.gitconnect.domain.member.dto.MemberRequestDto.MemberModifyReqDto;
+import com.twoclock.gitconnect.domain.member.dto.MemberResponseDto.MemberModifyRespDto;
+import com.twoclock.gitconnect.domain.member.service.MemberService;
+import com.twoclock.gitconnect.global.model.RestResponse;
+import com.twoclock.gitconnect.global.security.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
 @RestController
 public class MemberController {
+
+    private final MemberService memberService;
+
+    @PutMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public RestResponse modify(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestPart MemberModifyReqDto requestDto,
+            @RequestPart(required = false) MultipartFile multipartFile
+    ) {
+        String gitHubId = userDetails.getUsername();
+        MemberModifyRespDto responseDto = memberService.modify(gitHubId, requestDto, multipartFile);
+        return new RestResponse(responseDto);
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/global/config/S3Config.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/S3Config.java
@@ -1,0 +1,29 @@
+package com.twoclock.gitconnect.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.access.key}")
+    private String accessKey;
+
+    @Value("${aws.secret.key}")
+    private String secretKey;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .withRegion(Regions.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/global/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/twoclock/gitconnect/global/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,31 @@
+package com.twoclock.gitconnect.global.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -29,6 +29,7 @@ public class DummyDevlnit {
             // 테스트 계정 생성
             Member member = Member.builder()
                     .login("loginId")
+                    .gitHubId("1234")
                     .avatarUrl("/uploads/profile/test.jpg")
                     .name("테스트 유저")
                     .role(Role.ROLE_USER)

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
 
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "M-001", "찾을 수 없는 회원 계정입니다."),
     DIFF_USER_BOARD(HttpStatus.FORBIDDEN, "M-002", "게시글을 등록한 사용자와 일치하지 않습니다."),
+    ALREADY_EXIST_MEMBER(HttpStatus.BAD_REQUEST, "M-003", "이미 존재하는 회원 계정입니다."),
+    OVER_AVATAR_IMAGE_SIZE(HttpStatus.BAD_REQUEST, "M-004", "아바타 이미지 사이즈는 최대 5MB까지 가능합니다."),
+    INVALID_AVATAR_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "M-005", "업로드 할 수 없는 아바타 이미지 타입입니다."),
 
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "C-001", "찾을 수 없는 카테고리입니다."),
 

--- a/src/main/java/com/twoclock/gitconnect/global/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/twoclock/gitconnect/global/jwt/service/JwtRedisService.java
@@ -12,16 +12,16 @@ public class JwtRedisService {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void saveRefreshToken(String login, String refreshToken, long expiration) {
-        redisTemplate.opsForValue().set(login, refreshToken, expiration, TimeUnit.MILLISECONDS);
+    public void saveRefreshToken(String gitHubId, String refreshToken, long expiration) {
+        redisTemplate.opsForValue().set(gitHubId, refreshToken, expiration, TimeUnit.MILLISECONDS);
     }
 
-    public String getRefreshToken(String login) {
-        return redisTemplate.opsForValue().get(login);
+    public String getRefreshToken(String gitHubId) {
+        return redisTemplate.opsForValue().get(gitHubId);
     }
 
-    public void deleteRefreshToken(String login) {
-        redisTemplate.delete(login);
+    public void deleteRefreshToken(String gitHubId) {
+        redisTemplate.delete(gitHubId);
     }
 
     public void addToBlacklist(String jwtToken, long expiration) {

--- a/src/main/java/com/twoclock/gitconnect/global/jwt/service/JwtService.java
+++ b/src/main/java/com/twoclock/gitconnect/global/jwt/service/JwtService.java
@@ -5,13 +5,13 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
-@Slf4j
 @Service
 public class JwtService {
 
@@ -22,17 +22,19 @@ public class JwtService {
     public static final String BEARER_PREFIX = "Bearer ";
 
     public String generateAccessToken(Member member) {
-        String subject = member.getLogin();
-        String avatarUrl = member.getAvatarUrl();
-        String name = member.getName();
+        String subject = member.getGitHubId();
+
+        Map<String, String> claims = new HashMap<>();
+        claims.put("login", member.getLogin());
+        claims.put("avatarUrl", member.getAvatarUrl());
+        claims.put("name", member.getName());
 
         Date now = new Date();
         Date expiration = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION_TIME);
 
         return Jwts.builder()
                 .subject(subject)
-                .claim("avatarUrl", avatarUrl)
-                .claim("name", name)
+                .claims(claims)
                 .signWith(SECRET_KEY)
                 .issuedAt(now)
                 .expiration(expiration)
@@ -40,7 +42,7 @@ public class JwtService {
     }
 
     public String generateRefreshToken(Member member) {
-        String subject = member.getLogin();
+        String subject = member.getGitHubId();
 
         Date now = new Date();
         Date expiration = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME);
@@ -53,7 +55,7 @@ public class JwtService {
                 .compact();
     }
 
-    public String getLogin(String jwtToken) {
+    public String getGitHubId(String jwtToken) {
         return getSubject(jwtToken);
     }
 
@@ -84,7 +86,6 @@ public class JwtService {
                     .getSubject();
 
         } catch (JwtException e) {
-            log.error("JWT token validation failed", e);
             throw new JwtException("Invalid JWT signature", e);
         }
     }

--- a/src/main/java/com/twoclock/gitconnect/global/s3/service/S3Service.java
+++ b/src/main/java/com/twoclock/gitconnect/global/s3/service/S3Service.java
@@ -1,0 +1,39 @@
+package com.twoclock.gitconnect.global.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+
+    private final AmazonS3 s3Client;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(String keyName, MultipartFile file) throws IOException {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        PutObjectRequest request = new PutObjectRequest(bucket, keyName, file.getInputStream(), objectMetadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead);
+
+        s3Client.putObject(request);
+
+        return s3Client.getUrl(bucket, keyName).toString();
+    }
+
+    public void deleteFile(String keyName) {
+        DeleteObjectRequest request = new DeleteObjectRequest(bucket, keyName);
+        s3Client.deleteObject(request);
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/twoclock/gitconnect/global/security/JwtAuthenticationFilter.java
@@ -48,8 +48,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return;
             }
 
-            String login = jwtService.getLogin(jwtAccessToken);
-            UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(login);
+            String gitHubId = jwtService.getGitHubId(jwtAccessToken);
+            UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(gitHubId);
 
             UsernamePasswordAuthenticationToken authenticationToken =
                     new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/com/twoclock/gitconnect/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/global/security/UserDetailsImpl.java
@@ -2,7 +2,7 @@ package com.twoclock.gitconnect.global.security;
 
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.entity.constants.Role;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -11,10 +11,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.UUID;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class UserDetailsImpl implements UserDetails {
 
-    private Member member;
+    private final Member member;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -32,7 +32,7 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public String getUsername() {
-        return member.getName();
+        return member.getGitHubId();
     }
 
     @Override

--- a/src/main/java/com/twoclock/gitconnect/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/global/security/UserDetailsServiceImpl.java
@@ -16,7 +16,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByLogin(username)
+        Member member = memberRepository.findByGitHubId(username)
                 .orElseThrow(() -> new UsernameNotFoundException(username));
         return new UserDetailsImpl(member);
     }


### PR DESCRIPTION
## 관련 이슈

* #32 

## 변경 사항

- Member 엔티티에 GitHub Id 필드를 추가했습니다.
  - 기존에는 GitHub Login 필드로 JWT 토큰을 발급 했으나, 회원 정보를 수정할 시 JWT 토큰을 재발급 받아야 하는 문제점이 생겼습니다.
  - JWT 토큰의 subject 값을 GitHub Id 로 변경했습니다. (Access Token, Refresh Token)
- 회원 정보 수정 기능을 추가했습니다.
  - 회원 프로필 이미지를 업로드 할 시 S3 에 저장됩니다.
  - 업로드 된 기존 회원 프로필 이미지는 자동으로 삭제됩니다.
  - 수정 할 필드가 빈 값이라면 기존의 값을 넣어서 업데이트 되게끔 했습니다.
- application.yml 에 아래 내용 추가해주시면 됩니다.
  - 액세스 키와 시크릿 키는 슬랙에 올려뒀습니다.
  - S3 접속은 IAM 로그인으로 하시면 됩니다.
```yml
aws:
  access:
    key: 액세스 키
  secret:
    key: 시크릿 키
  s3:
    bucket: git-connect
```

### request
```curl
curl -X 'PUT' \
  'http://localhost:8082/api/v1/members' \
  -H 'accept: */*' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxNTA3MDQ2MzgiLCJhdmF0YXJVcmwiOiJodHRwczovL2F2YXRhcnMuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3UvMTUwNzA0NjM4P3Y9NCIsIm5hbWUiOiLquYDsiJjtmZgiLCJsb2dpbiI6Im9wZW5tcHkiLCJpYXQiOjE3MjM3MDc5NTEsImV4cCI6MTcyMzcwOTc1MX0.JDiFTAK93Qcs3aaJD5Uk8jO2beWKPGheYrUJ_-1yFAo' \
  -H 'Content-Type: multipart/form-data' \
  -F 'requestDto={
  "login": "samp2",
  "name": "ym"
}' \
  -F 'multipartFile=@9ed7b7b8-5277-4446-b43a-a5eacc3d76a8.png;type=image/png'
```

### response
```json
{
    "message": "OK",
    "data": {
        "login": "samp2",
        "avatarUrl": "~~",
        "name": "ym"
    }
}
```
<img width="1170" alt="스크린샷 2024-08-15 오후 4 53 08" src="https://github.com/user-attachments/assets/1b14f472-ba46-491c-9f4a-5cad861ef0ec">

<img width="1341" alt="스크린샷 2024-08-15 오후 4 50 58" src="https://github.com/user-attachments/assets/28fb0118-fc14-420e-9c7d-ca707bc77513">


## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?