### PR TITLE
feat: Implement GitHub token refresh and persistence

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberGitHubTokenDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberGitHubTokenDto.java
@@ -1,0 +1,7 @@
+package com.twoclock.gitconnect.domain.member.dto;
+
+public record MemberGitHubTokenDto(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberAuthRedisService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberAuthRedisService.java
@@ -1,0 +1,30 @@
+package com.twoclock.gitconnect.domain.member.service;
+
+import com.twoclock.gitconnect.domain.member.dto.MemberGitHubTokenDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberAuthRedisService {
+
+    private static final String GITHUB_ID = "github-id:";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void saveGitHubToken(String gitHubId, String gitHubAccessToken, String gitHubRefreshToken) {
+        String key = GITHUB_ID + gitHubId;
+        MemberGitHubTokenDto memberGitHubTokenDto = new MemberGitHubTokenDto(gitHubAccessToken, gitHubRefreshToken);
+        redisTemplate.opsForValue().set(key, memberGitHubTokenDto);
+    }
+
+    public MemberGitHubTokenDto getGitHubToken(String gitHubId) {
+        String key = GITHUB_ID + gitHubId;
+        return (MemberGitHubTokenDto) redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteGitHubToken(String gitHubId) {
+        redisTemplate.delete(GITHUB_ID + gitHubId);
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberAuthService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberAuthService.java
@@ -20,7 +20,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -33,7 +32,6 @@ import org.springframework.util.MultiValueMap;
 
 import java.util.Date;
 
-@Slf4j
 @RequiredArgsConstructor
 @Service
 public class MemberAuthService {

--- a/src/main/java/com/twoclock/gitconnect/global/config/RedisConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -15,7 +16,7 @@ public class RedisConfig {
         RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
-        redisTemplate.setKeySerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;

--- a/src/main/java/com/twoclock/gitconnect/global/constants/GitHubUri.java
+++ b/src/main/java/com/twoclock/gitconnect/global/constants/GitHubUri.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpMethod;
 public enum GitHubUri {
 
     ACCESS_TOKEN(HttpMethod.POST, "https://github.com/login/oauth/access_token?scope=user"),
-    USER_INFO(HttpMethod.GET, "https://api.github.com/user");
+    USER_INFO(HttpMethod.GET, "https://api.github.com/user"),
+    DELETE_TOKEN(HttpMethod.POST, "https://api.github.com/applications/%s/token");
 
     private final HttpMethod method;
     private final String uri;

--- a/src/main/java/com/twoclock/gitconnect/global/util/RestClientUtil.java
+++ b/src/main/java/com/twoclock/gitconnect/global/util/RestClientUtil.java
@@ -2,12 +2,15 @@ package com.twoclock.gitconnect.global.util;
 
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 public class RestClientUtil {
 
@@ -34,5 +37,17 @@ public class RestClientUtil {
                     throw new CustomException(ErrorCode.GITHUB_SERVER_ERROR);
                 }))
                 .body(String.class);
+    }
+
+    public static void delete(String uri, HttpHeaders headers, String body) {
+        restClient.method(HttpMethod.DELETE)
+                .uri(uri)
+                .headers(httpHeaders -> httpHeaders.addAll(headers))
+                .body(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, ((request, response) -> {
+                    throw new CustomException(ErrorCode.GITHUB_SERVER_ERROR);
+                }))
+                .toBodilessEntity();
     }
 }


### PR DESCRIPTION
## 관련 이슈

* #43 

## 변경 사항

- 로그인 시 GitHub Access Token 과 Refresh Token 이 Redis 에 저장됩니다.
  - 키 ``"github-id:1234"``, 밸류 ``"MemberGitHubTokenDto"``
- /refresh 엔드포인트 호출 시 새로운 GitHub Access Token 과 Refresh Token 이 발급됩니다.
  - 기존에 발급된 토큰들은 사용할 수 없게 됩니다.
- /logout 엔드포인트 호출 시 발급된 GitHub Acess Token 과 Refresh Token 을 사용할 수 없게 됩니다. 
<img width="924" alt="스크린샷 2024-08-16 오후 6 40 32" src="https://github.com/user-attachments/assets/2a8471b2-b9ba-4866-bc9b-83708bfe78e7">


## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?