### PR TITLE
feat: add Github API following/follower list using accessToken

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/global/constants/GitHubUri.java
+++ b/src/main/java/com/twoclock/gitconnect/global/constants/GitHubUri.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpMethod;
 public enum GitHubUri {
 
     ACCESS_TOKEN(HttpMethod.POST, "https://github.com/login/oauth/access_token?scope=user"),
-    USER_INFO(HttpMethod.GET, "https://api.github.com/user");
+    USER_INFO(HttpMethod.GET, "https://api.github.com/user"),
+    FOLLOWER_LIST(HttpMethod.GET, "https://api.github.com/user/followers"),
+    FOLLOWING_LIST(HttpMethod.GET, "https://api.github.com/user/following");
 
     private final HttpMethod method;
     private final String uri;

--- a/src/main/java/com/twoclock/gitconnect/openapi/github/dto/FollowRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/openapi/github/dto/FollowRespDto.java
@@ -1,0 +1,8 @@
+package com.twoclock.gitconnect.openapi.github.dto;
+
+public record FollowRespDto(
+        String login,
+        String avatarUrl,
+        String htmlUrl
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/openapi/github/service/GithubAPISerivce.java
+++ b/src/main/java/com/twoclock/gitconnect/openapi/github/service/GithubAPISerivce.java
@@ -25,6 +25,12 @@ public class GithubAPISerivce {
         return getFollowersFromJson(result);
     }
 
+    public List<FollowRespDto> getFollowing(String accessToken) throws JsonProcessingException {
+        HttpHeaders headers = getHeaders(accessToken);
+        String result = RestClientUtil.get(GitHubUri.FOLLOWING_LIST.getUri(), headers);
+        return getFollowersFromJson(result);
+    }
+
     private HttpHeaders getHeaders(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Accept", "application/vnd.github+json");

--- a/src/main/java/com/twoclock/gitconnect/openapi/github/service/GithubAPISerivce.java
+++ b/src/main/java/com/twoclock/gitconnect/openapi/github/service/GithubAPISerivce.java
@@ -1,9 +1,51 @@
 package com.twoclock.gitconnect.openapi.github.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.twoclock.gitconnect.global.constants.GitHubUri;
+import com.twoclock.gitconnect.global.util.RestClientUtil;
+import com.twoclock.gitconnect.openapi.github.dto.FollowRespDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class GithubAPISerivce {
+
+    private final ObjectMapper objectMapper;
+
+    public List<FollowRespDto> getFollowers(String accessToken) throws JsonProcessingException {
+        HttpHeaders headers = getHeaders(accessToken);
+        String result = RestClientUtil.get(GitHubUri.FOLLOWER_LIST.getUri(), headers);
+        return getFollowersFromJson(result);
+    }
+
+    private HttpHeaders getHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Accept", "application/vnd.github+json");
+        headers.add("X-GitHub-Api-Version", "2022-11-28");
+        headers.add("Authorization", "Bearer " + accessToken);
+        return headers;
+    }
+
+    private List<FollowRespDto> getFollowersFromJson(String result) throws JsonProcessingException {
+        try {
+            List<FollowRespDto> users = new ArrayList<>();
+            JsonNode arrayNode  = objectMapper.readTree(result);
+            for (JsonNode node : arrayNode) {
+                String login = node.path("login").asText();
+                String avatarUrl = node.path("avatar_url").asText();
+                String gravatarId = node.path("html_url").asText();
+                users.add(new FollowRespDto(login, avatarUrl, gravatarId));
+            }
+            return users;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/openapi/github/service/GithubAPISerivce.java
+++ b/src/main/java/com/twoclock/gitconnect/openapi/github/service/GithubAPISerivce.java
@@ -1,0 +1,9 @@
+package com.twoclock.gitconnect.openapi.github.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GithubAPISerivce {
+}

--- a/src/main/java/com/twoclock/gitconnect/openapi/github/service/GithubAPIService.java
+++ b/src/main/java/com/twoclock/gitconnect/openapi/github/service/GithubAPIService.java
@@ -15,17 +15,17 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class GithubAPISerivce {
+public class GithubAPIService {
 
     private final ObjectMapper objectMapper;
 
-    public List<FollowRespDto> getFollowers(String accessToken) throws JsonProcessingException {
+    public List<FollowRespDto> getFollowers(String accessToken) {
         HttpHeaders headers = getHeaders(accessToken);
         String result = RestClientUtil.get(GitHubUri.FOLLOWER_LIST.getUri(), headers);
         return getFollowersFromJson(result);
     }
 
-    public List<FollowRespDto> getFollowing(String accessToken) throws JsonProcessingException {
+    public List<FollowRespDto> getFollowing(String accessToken) {
         HttpHeaders headers = getHeaders(accessToken);
         String result = RestClientUtil.get(GitHubUri.FOLLOWING_LIST.getUri(), headers);
         return getFollowersFromJson(result);
@@ -39,7 +39,7 @@ public class GithubAPISerivce {
         return headers;
     }
 
-    private List<FollowRespDto> getFollowersFromJson(String result) throws JsonProcessingException {
+    private List<FollowRespDto> getFollowersFromJson(String result) {
         try {
             List<FollowRespDto> users = new ArrayList<>();
             JsonNode arrayNode  = objectMapper.readTree(result);

--- a/src/main/java/com/twoclock/gitconnect/openapi/github/web/GithubAPIController.java
+++ b/src/main/java/com/twoclock/gitconnect/openapi/github/web/GithubAPIController.java
@@ -1,9 +1,16 @@
 package com.twoclock.gitconnect.openapi.github.web;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.twoclock.gitconnect.global.model.RestResponse;
+import com.twoclock.gitconnect.openapi.github.dto.FollowRespDto;
 import com.twoclock.gitconnect.openapi.github.service.GithubAPISerivce;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/github")
@@ -11,4 +18,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class GithubAPIController {
 
     private final GithubAPISerivce githubAPISerivce;
+
+    // 임시용
+    @Value("${github.access-token}")
+    private String accessToken;
+
+    @GetMapping("/followers")
+    public RestResponse getFollowers() throws JsonProcessingException {
+        // TODO : 토큰에서 Github Access Token을 추출 해야함.
+        List<FollowRespDto> result = githubAPISerivce.getFollowers(accessToken);
+        return new RestResponse(result);
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/openapi/github/web/GithubAPIController.java
+++ b/src/main/java/com/twoclock/gitconnect/openapi/github/web/GithubAPIController.java
@@ -29,4 +29,11 @@ public class GithubAPIController {
         List<FollowRespDto> result = githubAPISerivce.getFollowers(accessToken);
         return new RestResponse(result);
     }
+
+    @GetMapping("/following")
+    public RestResponse getFollowing() throws JsonProcessingException {
+        // TODO : 토큰에서 Github Access Token을 추출 해야함.
+        List<FollowRespDto> result = githubAPISerivce.getFollowing(accessToken);
+        return new RestResponse(result);
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/openapi/github/web/GithubAPIController.java
+++ b/src/main/java/com/twoclock/gitconnect/openapi/github/web/GithubAPIController.java
@@ -1,9 +1,8 @@
 package com.twoclock.gitconnect.openapi.github.web;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.twoclock.gitconnect.global.model.RestResponse;
 import com.twoclock.gitconnect.openapi.github.dto.FollowRespDto;
-import com.twoclock.gitconnect.openapi.github.service.GithubAPISerivce;
+import com.twoclock.gitconnect.openapi.github.service.GithubAPIService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,23 +16,23 @@ import java.util.List;
 @RestController
 public class GithubAPIController {
 
-    private final GithubAPISerivce githubAPISerivce;
+    private final GithubAPIService githubAPIService;
 
     // 임시용
     @Value("${github.access-token}")
     private String accessToken;
 
     @GetMapping("/followers")
-    public RestResponse getFollowers() throws JsonProcessingException {
+    public RestResponse getFollowers() {
         // TODO : 토큰에서 Github Access Token을 추출 해야함.
-        List<FollowRespDto> result = githubAPISerivce.getFollowers(accessToken);
+        List<FollowRespDto> result = githubAPIService.getFollowers(accessToken);
         return new RestResponse(result);
     }
 
     @GetMapping("/following")
-    public RestResponse getFollowing() throws JsonProcessingException {
+    public RestResponse getFollowing() {
         // TODO : 토큰에서 Github Access Token을 추출 해야함.
-        List<FollowRespDto> result = githubAPISerivce.getFollowing(accessToken);
+        List<FollowRespDto> result = githubAPIService.getFollowing(accessToken);
         return new RestResponse(result);
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/openapi/github/web/GithubAPIController.java
+++ b/src/main/java/com/twoclock/gitconnect/openapi/github/web/GithubAPIController.java
@@ -1,0 +1,14 @@
+package com.twoclock.gitconnect.openapi.github.web;
+
+import com.twoclock.gitconnect.openapi.github.service.GithubAPISerivce;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/github")
+@RestController
+public class GithubAPIController {
+
+    private final GithubAPISerivce githubAPISerivce;
+}


### PR DESCRIPTION
## 관련 이슈

* #38 

## 변경 사항
> 실제 Github Following/Follower List 요청 시 반환되는 Response
```
{
        "login": "youchanKim",
        "id": 132042138,
        "node_id": "U_kgDOB97Nmg",
        "avatar_url": "https://avatars.githubusercontent.com/u/132042138?v=4",
        "gravatar_id": "",
        "url": "https://api.github.com/users/youchanKim",
        "html_url": "https://github.com/youchanKim",
        "followers_url": "https://api.github.com/users/youchanKim/followers",
        "following_url": "https://api.github.com/users/youchanKim/following{/other_user}",
        "gists_url": "https://api.github.com/users/youchanKim/gists{/gist_id}",
        "starred_url": "https://api.github.com/users/youchanKim/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/youchanKim/subscriptions",
        "organizations_url": "https://api.github.com/users/youchanKim/orgs",
        "repos_url": "https://api.github.com/users/youchanKim/repos",
        "events_url": "https://api.github.com/users/youchanKim/events{/privacy}",
        "received_events_url": "https://api.github.com/users/youchanKim/received_events",
        "type": "User",
        "site_admin": false
    },
```

following/follower 목록 API를 요청했을 때 반환받는 필드 대부분 다시 API를 요청할 수 있는 주소로 반환되어
단순 목록 확인용으로 사용할 수 있는 `login`, `avatar_url`, `html_url` 만 반환 받도록 설정하였습니다. 

> 로그인 한 사용자의 Follow 목록 조회 API -> `/api/v1/github/following`
```
Response

{
    "message": "OK",
    "data": [
        {
            "login": "wbluke",
            "avatarUrl": "https://avatars.githubusercontent.com/u/44018338?v=4",
            "htmlUrl": "https://github.com/wbluke"
        },
        {
            "login": "9898s",
            "avatarUrl": "https://avatars.githubusercontent.com/u/46531692?v=4",
            "htmlUrl": "https://github.com/9898s"
        },
        {
            "login": "devFancy",
            "avatarUrl": "https://avatars.githubusercontent.com/u/83820185?v=4",
            "htmlUrl": "https://github.com/devFancy"
        },
        {...},
    ]
}

```

> 로그인 한 사용자의 Follower 목록 조회 API -> `/api/v1/github/followers`
```
Response
{
    "message": "OK",
    "data": [
        {
            "login": "9898s",
            "avatarUrl": "https://avatars.githubusercontent.com/u/46531692?v=4",
            "htmlUrl": "https://github.com/9898s"
        },
        {
            "login": "youchanKim",
            "avatarUrl": "https://avatars.githubusercontent.com/u/132042138?v=4",
            "htmlUrl": "https://github.com/youchanKim"
        },
        {
            "login": "Peter-Yu-0402",
            "avatarUrl": "https://avatars.githubusercontent.com/u/149031461?v=4",
            "htmlUrl": "https://github.com/Peter-Yu-0402"
        },
        {
            "login": "openmpy",
            "avatarUrl": "https://avatars.githubusercontent.com/u/150704638?v=4",
            "htmlUrl": "https://github.com/openmpy"
        }
    ]
}

```

해당 API를 사용하기 위해서는 yml 설정 파일에 access-token을 추가 하여야 합니다.
```
github:
  client-id: ${github.client-id}
  client-secret: ${github.client-secret}
  redirect-uri: ${github.redirect-uri}
  access-token: ${ 여기에 로그인 처리 과정에서 발급받은 access Token 넣어주세요~}
```
추후 로그인 과정에서 Redis에 토큰이 저장되면 로직 변경 예정입니다.


## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?