### PR TITLE
feat: add Board like API

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/like/entity/Like.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/entity/Like.java
@@ -4,15 +4,19 @@ import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@Table(name = "likes")
+@EntityListeners(AuditingEntityListener.class)
 public class Like {
 
     @Id
@@ -30,5 +34,11 @@ public class Like {
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdDateTime;
+
+    @Builder
+    public Like(Board board, Member member) {
+        this.board = board;
+        this.member = member;
+    }
 
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/entity/Like.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/entity/Like.java
@@ -1,0 +1,34 @@
+package com.twoclock.gitconnect.domain.like.entity;
+
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDateTime;
+
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/like/entity/Likes.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/entity/Likes.java
@@ -15,9 +15,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-@Table(name = "likes")
 @EntityListeners(AuditingEntityListener.class)
-public class Like {
+public class Likes {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,7 +35,7 @@ public class Like {
     private LocalDateTime createdDateTime;
 
     @Builder
-    public Like(Board board, Member member) {
+    public Likes(Board board, Member member) {
         this.board = board;
         this.member = member;
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
@@ -1,10 +1,10 @@
 package com.twoclock.gitconnect.domain.like.repository;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
-import com.twoclock.gitconnect.domain.like.entity.Like;
+import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LikeRepository extends JpaRepository<Like, Long> {
+public interface LikeRepository extends JpaRepository<Likes, Long> {
     boolean existsByBoardAndMember(Board board, Member member);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
@@ -1,0 +1,10 @@
+package com.twoclock.gitconnect.domain.like.repository;
+
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.like.entity.Like;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    boolean existsByBoardAndMember(Board board, Member member);
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
@@ -5,6 +5,9 @@ import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikeRepository extends JpaRepository<Likes, Long> {
     boolean existsByBoardAndMember(Board board, Member member);
+    Optional<Likes> findByBoardAndMember(Board board, Member member);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -21,9 +21,9 @@ public class LikeService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void addLikeToBoard(Long boardId, Long userId) {
+    public void addLikeToBoard(Long boardId, String githubId) {
         Board board = validateBoard(boardId);
-        Member member = validateMember(userId);
+        Member member = validateMember(githubId);
         boolean duplicated = likeRepository.existsByBoardAndMember(board, member);
         if (duplicated) {
             throw new CustomException(ErrorCode.DUPLICATED_LIKE);
@@ -37,9 +37,9 @@ public class LikeService {
     }
 
     @Transactional
-    public void deleteLikeToBoard(Long boardId, Long userId) {
+    public void deleteLikeToBoard(Long boardId, String githubId) {
         Board board = validateBoard(boardId);
-        Member member = validateMember(userId);
+        Member member = validateMember(githubId);
         Likes likes = likeRepository.findByBoardAndMember(board, member).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_LIKE)
         );
@@ -52,8 +52,8 @@ public class LikeService {
         );
     }
 
-    private Member validateMember(Long userId) {
-        return memberRepository.findById(userId).orElseThrow(
+    private Member validateMember(String githubId) {
+        return memberRepository.findByGitHubId(githubId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
         );
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -1,0 +1,42 @@
+package com.twoclock.gitconnect.domain.like.service;
+
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
+import com.twoclock.gitconnect.domain.like.entity.Like;
+import com.twoclock.gitconnect.domain.like.repository.LikeRepository;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void addLikeToBoard(Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_BOARD)
+        );
+        Member member = memberRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
+        );
+        boolean duplicated = likeRepository.existsByBoardAndMember(board, member);
+        if (duplicated) {
+            throw new CustomException(ErrorCode.DUPLICATED_LIKE);
+        }
+
+        Like like = Like.builder()
+                .board(board)
+                .member(member)
+                .build();
+        likeRepository.save(like);
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -2,7 +2,7 @@ package com.twoclock.gitconnect.domain.like.service;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
-import com.twoclock.gitconnect.domain.like.entity.Like;
+import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.like.repository.LikeRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
@@ -33,10 +33,10 @@ public class LikeService {
             throw new CustomException(ErrorCode.DUPLICATED_LIKE);
         }
 
-        Like like = Like.builder()
+        Likes likes = Likes.builder()
                 .board(board)
                 .member(member)
                 .build();
-        likeRepository.save(like);
+        likeRepository.save(likes);
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -22,12 +22,8 @@ public class LikeService {
 
     @Transactional
     public void addLikeToBoard(Long boardId, Long userId) {
-        Board board = boardRepository.findById(boardId).orElseThrow(
-                () -> new CustomException(ErrorCode.NOT_FOUND_BOARD)
-        );
-        Member member = memberRepository.findById(userId).orElseThrow(
-                () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
-        );
+        Board board = validateBoard(boardId);
+        Member member = validateMember(userId);
         boolean duplicated = likeRepository.existsByBoardAndMember(board, member);
         if (duplicated) {
             throw new CustomException(ErrorCode.DUPLICATED_LIKE);
@@ -38,5 +34,17 @@ public class LikeService {
                 .member(member)
                 .build();
         likeRepository.save(likes);
+    }
+
+    private Board validateBoard(Long boardId) {
+        return boardRepository.findById(boardId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_BOARD)
+        );
+    }
+
+    private Member validateMember(Long userId) {
+        return memberRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
+        );
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -36,6 +36,16 @@ public class LikeService {
         likeRepository.save(likes);
     }
 
+    @Transactional
+    public void deleteLikeToBoard(Long boardId, Long userId) {
+        Board board = validateBoard(boardId);
+        Member member = validateMember(userId);
+        Likes likes = likeRepository.findByBoardAndMember(board, member).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_LIKE)
+        );
+        likeRepository.delete(likes);
+    }
+
     private Board validateBoard(Long boardId) {
         return boardRepository.findById(boardId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_BOARD)

--- a/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/like")
+@RequestMapping("/api/v1/likes")
 public class LikeController {
 
     private final LikeService likeService;

--- a/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
@@ -2,7 +2,9 @@ package com.twoclock.gitconnect.domain.like.web;
 
 import com.twoclock.gitconnect.domain.like.service.LikeService;
 import com.twoclock.gitconnect.global.model.RestResponse;
+import com.twoclock.gitconnect.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,16 +15,18 @@ public class LikeController {
     private final LikeService likeService;
 
     @PostMapping("/{boardId}")
-    public RestResponse addLikeToBoard(@PathVariable("boardId") Long boardId) {
-        Long userId = 1L;
-        likeService.addLikeToBoard(boardId, userId);
+    public RestResponse addLikeToBoard(@PathVariable("boardId") Long boardId,
+                                       @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        String githubId = userDetails.getUsername();
+        likeService.addLikeToBoard(boardId, githubId);
         return RestResponse.OK();
     }
 
     @DeleteMapping("/{boardId}")
-    public RestResponse deleteLikeToBoard(@PathVariable("boardId") Long boardId) {
-        Long userId = 1L;
-        likeService.deleteLikeToBoard(boardId, userId);
+    public RestResponse deleteLikeToBoard(@PathVariable("boardId") Long boardId,
+                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        String githubId = userDetails.getUsername();
+        likeService.deleteLikeToBoard(boardId, githubId);
         return RestResponse.OK();
     }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
@@ -3,10 +3,7 @@ package com.twoclock.gitconnect.domain.like.web;
 import com.twoclock.gitconnect.domain.like.service.LikeService;
 import com.twoclock.gitconnect.global.model.RestResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,10 +13,16 @@ public class LikeController {
     private final LikeService likeService;
 
     @PostMapping("/{boardId}")
-    public RestResponse addLikeToBoard(@PathVariable("boardId") Long boardId){
+    public RestResponse addLikeToBoard(@PathVariable("boardId") Long boardId) {
         Long userId = 1L;
-
         likeService.addLikeToBoard(boardId, userId);
+        return RestResponse.OK();
+    }
+
+    @DeleteMapping("/{boardId}")
+    public RestResponse deleteLikeToBoard(@PathVariable("boardId") Long boardId) {
+        Long userId = 1L;
+        likeService.deleteLikeToBoard(boardId, userId);
         return RestResponse.OK();
     }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
@@ -1,0 +1,28 @@
+package com.twoclock.gitconnect.domain.like.web;
+
+import com.twoclock.gitconnect.domain.like.service.LikeService;
+import com.twoclock.gitconnect.global.model.RestResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/like")
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping("/{boardId}")
+    public RestResponse addLikeToBoard(@PathVariable("boardId") Long boardId){
+        Long userId = 1L;
+
+        likeService.addLikeToBoard(boardId, userId);
+        return RestResponse.OK();
+    }
+
+
+
+}

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -28,6 +28,8 @@ public enum ErrorCode {
     FAIL_SAVE_BOARD(HttpStatus.INTERNAL_SERVER_ERROR, "B-001", "게시글 저장에 실패하였습니다."),
     FAIL_MODIFY_BOARD(HttpStatus.INTERNAL_SERVER_ERROR, "B-002", "게시글 수정에 실패하였습니다."),
     NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, "B-003", "해당 게시판을 찾을 수 없습니다."),
+
+    DUPLICATED_LIKE(HttpStatus.BAD_REQUEST, "L-001", "이미 좋아요를 누른 게시글입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
     NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, "B-003", "해당 게시판을 찾을 수 없습니다."),
 
     DUPLICATED_LIKE(HttpStatus.BAD_REQUEST, "L-001", "이미 좋아요를 누른 게시글입니다."),
-    ;
+    NOT_FOUND_LIKE(HttpStatus.BAD_REQUEST, "L-002", "좋아요를 누른 게시글을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 관련 이슈

* #46 

## 변경 사항

**게시글에 대해서 좋아요를 등록할 수 있음**
  - 이미 좋아요를 누른 게시글에 대해서는 좋아요를 추가할 수 없음
  - 게시글이 삭제되지 않은 상태이며 사용자도 존재해야함
> API : `/api/v1/like/{boardId}`   [Post]

![image](https://github.com/user-attachments/assets/764ef825-15a8-4cd2-ba87-7dc343e2252a)



**좋아요 눌렀던 게시글에 대해서 좋아요 취소할 수 있음**
  - 자신이 좋아요를 눌렀던 게시글에 대해서만 삭제 처리를 할 수 있음
> API : `/api/v1/like/{boardId}`   [Delete]
(DB에서 값 자체를 삭제하는 Delete 처리)

## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?
