### PR TITLE
feat: Add API to check Likes of board

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikesRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikesRespDto.java
@@ -1,5 +1,7 @@
 package com.twoclock.gitconnect.domain.like.dto;
 
+import com.twoclock.gitconnect.domain.like.entity.Likes;
+
 import java.time.LocalDateTime;
 
 public record LikesRespDto(
@@ -10,4 +12,14 @@ public record LikesRespDto(
         String gitHubId,
         LocalDateTime createdDateTime
 ) {
+    public LikesRespDto(Likes likes) {
+        this(
+                likes.getId(),
+                likes.getMember().getLogin(),
+                likes.getMember().getAvatarUrl(),
+                likes.getMember().getName(),
+                likes.getMember().getGitHubId(),
+                likes.getCreatedDateTime()
+        );
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikesRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikesRespDto.java
@@ -1,0 +1,13 @@
+package com.twoclock.gitconnect.domain.like.dto;
+
+import java.time.LocalDateTime;
+
+public record LikesRespDto(
+        Long id,
+        String login,
+        String avatarUrl,
+        String name,
+        String gitHubId,
+        LocalDateTime createdDateTime
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
@@ -5,9 +5,11 @@ import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Likes, Long> {
     boolean existsByBoardAndMember(Board board, Member member);
     Optional<Likes> findByBoardAndMember(Board board, Member member);
+    List<Likes> findAllByBoard(Board board);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -2,6 +2,7 @@ package com.twoclock.gitconnect.domain.like.service;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
+import com.twoclock.gitconnect.domain.like.dto.LikesRespDto;
 import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.like.repository.LikeRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
@@ -11,6 +12,9 @@ import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -44,6 +48,14 @@ public class LikeService {
                 () -> new CustomException(ErrorCode.NOT_FOUND_LIKE)
         );
         likeRepository.delete(likes);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LikesRespDto> getLikesByBoardId(Long boardId) {
+        Board board = validateBoard(boardId);
+        List<Likes> likes = likeRepository.findAllByBoard(board);
+        List<LikesRespDto> response = likes.stream().map(LikesRespDto::new).toList();
+        return response;
     }
 
     private Board validateBoard(Long boardId) {

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -54,8 +54,7 @@ public class LikeService {
     public List<LikesRespDto> getLikesByBoardId(Long boardId) {
         Board board = validateBoard(boardId);
         List<Likes> likes = likeRepository.findAllByBoard(board);
-        List<LikesRespDto> response = likes.stream().map(LikesRespDto::new).toList();
-        return response;
+        return likes.stream().map(LikesRespDto::new).toList();
     }
 
     private Board validateBoard(Long boardId) {

--- a/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
@@ -1,11 +1,14 @@
 package com.twoclock.gitconnect.domain.like.web;
 
+import com.twoclock.gitconnect.domain.like.dto.LikesRespDto;
 import com.twoclock.gitconnect.domain.like.service.LikeService;
 import com.twoclock.gitconnect.global.model.RestResponse;
 import com.twoclock.gitconnect.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,6 +33,9 @@ public class LikeController {
         return RestResponse.OK();
     }
 
-
-
+    @GetMapping("/{boardId}")
+    public RestResponse getLikesByBoardId(@PathVariable("boardId") Long boardId) {
+        List<LikesRespDto> result = likeService.getLikesByBoardId(boardId);
+        return new RestResponse(result);
+    }
 }


### PR DESCRIPTION
## 관련 이슈

* #52 

## 변경 사항
게시글의 ID를 사용하여 좋아요 목록을 확인할 수 있는 API 추가
> API : `/api/v1/likes/{boardId}` (Get)

**Response**
```
{
    "message": "OK",
    "data": [
        {
            "id": 1,
            "login": "jjangsky",
            "avatarUrl": "https://avatars.githubusercontent.com/u/103441154?v=4",
            "name": "짱스키",
            "gitHubId": "103441154",
            "createdDateTime": "2024-08-20T23:15:18.067118"
        }
    ]
}
```

만약 게시글의 좋아요가 없는 경우는 따로 Exception 처리를 하지 않고 빈 배열을 반환시킵니다.
```
{
    "message": "OK",
    "data": []
}
```


## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?
