### PR TITLE
feat: Add WebSocket Support and MongoDB Integration for Chat Room Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ application-local.yml
 
 ### Docker ###
 mysql-data/
+mongodb-data/

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // Spring Web Socket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -49,13 +52,14 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
     // Slack-Api
     implementation 'net.gpedro.integrations.slack:slack-webhook:1.4.0'
 
     // Querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor"com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor("com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 

--- a/compose.yml
+++ b/compose.yml
@@ -18,3 +18,14 @@ services:
     image: redis:7.2
     ports:
       - 6379:6379
+  mongodb:
+    container_name: mongodb
+    image: mongo:latest
+    restart: always
+    ports:
+      - 27017:27017
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=1234
+    volumes:
+      - ./mongodb-data:/data

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatMessageSaveReqDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatMessageSaveReqDto.java
@@ -1,0 +1,6 @@
+package com.twoclock.gitconnect.domain.chat.dto;
+
+public record ChatMessageSaveReqDto(
+        String message
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatMessageSaveReqDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatMessageSaveReqDto.java
@@ -1,6 +1,9 @@
 package com.twoclock.gitconnect.domain.chat.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record ChatMessageSaveReqDto(
+        @NotBlank(message = "내용을 입력해주세요.")
         String message
 ) {
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatMessageSaveRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatMessageSaveRespDto.java
@@ -1,0 +1,11 @@
+package com.twoclock.gitconnect.domain.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageSaveRespDto(
+        String login,
+        String gitHubId,
+        String message,
+        LocalDateTime createdDateTime
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/entity/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.twoclock.gitconnect.domain.chat.entity;
 
+import com.twoclock.gitconnect.domain.member.entity.Member;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,14 +18,14 @@ public class ChatMessage {
     @Id
     private String id;
     private String chatRoomId;
-    private String senderGitHubId;
+    private Member senderMember;
     private String message;
     private LocalDateTime createdDateTime;
 
     @Builder
-    public ChatMessage(String chatRoomId, String senderGitHubId, String message, LocalDateTime createdDateTime) {
+    public ChatMessage(String chatRoomId, Member senderMember, String message, LocalDateTime createdDateTime) {
         this.chatRoomId = chatRoomId;
-        this.senderGitHubId = senderGitHubId;
+        this.senderMember = senderMember;
         this.message = message;
         this.createdDateTime = createdDateTime;
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,31 @@
+package com.twoclock.gitconnect.domain.chat.entity;
+
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Document(collection = "messages")
+public class ChatMessage {
+
+    @Id
+    private String id;
+    private String chatRoomId;
+    private String senderGitHubId;
+    private String message;
+    private LocalDateTime createdDateTime;
+
+    @Builder
+    public ChatMessage(String chatRoomId, String senderGitHubId, String message, LocalDateTime createdDateTime) {
+        this.chatRoomId = chatRoomId;
+        this.senderGitHubId = senderGitHubId;
+        this.message = message;
+        this.createdDateTime = createdDateTime;
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,44 @@
+package com.twoclock.gitconnect.domain.chat.entity;
+
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@SQLDelete(sql = "UPDATE chat_room SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String chatRoomId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_member_id", nullable = false)
+    private Member createdMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "received_member_id", nullable = false)
+    private Member receivedMember;
+
+    @Column(nullable = false)
+    private final Boolean isDeleted = Boolean.FALSE;
+
+    @Builder
+    public ChatRoom(String chatRoomId, Member createdMember, Member receivedMember) {
+        this.chatRoomId = chatRoomId;
+        this.createdMember = createdMember;
+        this.receivedMember = receivedMember;
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.twoclock.gitconnect.domain.chat.repository;
+
+import com.twoclock.gitconnect.domain.chat.entity.ChatMessage;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepository.java
@@ -3,7 +3,11 @@ package com.twoclock.gitconnect.domain.chat.repository;
 import com.twoclock.gitconnect.domain.chat.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     boolean existsByChatRoomId(String chatRoomId);
+
+    Optional<ChatRoom> findByChatRoomId(String chatRoomId);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package com.twoclock.gitconnect.domain.chat.repository;
+
+import com.twoclock.gitconnect.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    boolean existsByChatRoomId(String chatRoomId);
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
@@ -31,14 +31,17 @@ public class ChatMessageService {
 
         ChatMessage chatMessage = ChatMessage.builder()
                 .chatRoomId(chatRoom.getChatRoomId())
-                .senderGitHubId(member.getGitHubId())
+                .senderMember(member)
                 .message(chatMessageSaveReqDto.message())
                 .createdDateTime(LocalDateTime.now())
                 .build();
         chatMessageRepository.save(chatMessage);
 
         return new ChatMessageSaveRespDto(
-                member.getLogin(), member.getGitHubId(), chatMessage.getMessage(), chatMessage.getCreatedDateTime()
+                chatMessage.getSenderMember().getLogin(),
+                chatMessage.getSenderMember().getGitHubId(),
+                chatMessage.getMessage(),
+                chatMessage.getCreatedDateTime()
         );
     }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,56 @@
+package com.twoclock.gitconnect.domain.chat.service;
+
+import com.twoclock.gitconnect.domain.chat.dto.ChatMessageSaveReqDto;
+import com.twoclock.gitconnect.domain.chat.dto.ChatMessageSaveRespDto;
+import com.twoclock.gitconnect.domain.chat.entity.ChatMessage;
+import com.twoclock.gitconnect.domain.chat.entity.ChatRoom;
+import com.twoclock.gitconnect.domain.chat.repository.ChatMessageRepository;
+import com.twoclock.gitconnect.domain.chat.repository.ChatRoomRepository;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final MemberRepository memberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Transactional
+    public ChatMessageSaveRespDto sendMessage(String gitHubId, String chatRoomId, ChatMessageSaveReqDto chatMessageSaveReqDto) {
+        Member member = validateMemberByGitHubId(gitHubId);
+        ChatRoom chatRoom = validateChatRoomById(chatRoomId);
+
+        ChatMessage chatMessage = ChatMessage.builder()
+                .chatRoomId(chatRoom.getChatRoomId())
+                .senderGitHubId(member.getGitHubId())
+                .message(chatMessageSaveReqDto.message())
+                .createdDateTime(LocalDateTime.now())
+                .build();
+        chatMessageRepository.save(chatMessage);
+
+        return new ChatMessageSaveRespDto(
+                member.getLogin(), member.getGitHubId(), chatMessage.getMessage(), chatMessage.getCreatedDateTime()
+        );
+    }
+
+    private Member validateMemberByGitHubId(String gitHubId) {
+        return memberRepository.findByGitHubId(gitHubId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
+        );
+    }
+
+    private ChatRoom validateChatRoomById(String chatRoomId) {
+        return chatRoomRepository.findByChatRoomId(chatRoomId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_CHAT_ROOM)
+        );
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
@@ -21,8 +21,8 @@ public class ChatRoomService {
 
     @Transactional
     public void createChatRoom(String createdGitHubId, String receiveGitHubId) {
-        Member createdMember = validateMember(createdGitHubId);
-        Member receiveMember = validateMember(receiveGitHubId);
+        Member createdMember = validateMemberByGitHubId(createdGitHubId);
+        Member receiveMember = validateMemberByGitHubId(receiveGitHubId);
 
         String chatRoomId = getChatRoomId(createdMember.getGitHubId(), receiveMember.getGitHubId());
 
@@ -37,21 +37,21 @@ public class ChatRoomService {
 
     @Transactional
     public void deleteChatRoom(String githubId, Long id) {
-        Member member = validateMember(githubId);
-        ChatRoom chatRoom = validateChatRoom(id);
+        Member member = validateMemberByGitHubId(githubId);
+        ChatRoom chatRoom = validateChatRoomById(id);
 
         checkAccessChatRoom(member.getGitHubId(), chatRoom.getChatRoomId());
         chatRoomRepository.delete(chatRoom);
     }
 
-    private ChatRoom validateChatRoom(Long id) {
+    private ChatRoom validateChatRoomById(Long id) {
         return chatRoomRepository.findById(id).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_CHAT_ROOM)
         );
     }
 
-    private Member validateMember(String createdGitHubId) {
-        return memberRepository.findByGitHubId(createdGitHubId).orElseThrow(
+    private Member validateMemberByGitHubId(String gitHubId) {
+        return memberRepository.findByGitHubId(gitHubId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
         );
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
@@ -26,7 +26,7 @@ public class ChatRoomService {
         Member createdMember = validateMemberByGitHubId(createdGitHubId);
         Member receiveMember = validateMemberByGitHubId(receiveGitHubId);
 
-        String chatRoomId = getChatRoomId(createdMember.getGitHubId(), receiveMember.getGitHubId());
+        String chatRoomId = generateChatRoomId(createdMember.getGitHubId(), receiveMember.getGitHubId());
 
         ChatRoom chatRoom = ChatRoom.builder()
                 .chatRoomId(chatRoomId)
@@ -38,16 +38,16 @@ public class ChatRoomService {
     }
 
     @Transactional
-    public void deleteChatRoom(String githubId, Long id) {
+    public void deleteChatRoom(String githubId, String chatRoomId) {
         Member member = validateMemberByGitHubId(githubId);
-        ChatRoom chatRoom = validateChatRoomById(id);
+        ChatRoom chatRoom = validateChatRoomById(chatRoomId);
 
         checkAccessChatRoom(member.getGitHubId(), chatRoom.getChatRoomId());
         chatRoomRepository.delete(chatRoom);
     }
 
-    private ChatRoom validateChatRoomById(Long id) {
-        return chatRoomRepository.findById(id).orElseThrow(
+    private ChatRoom validateChatRoomById(String chatRoomId) {
+        return chatRoomRepository.findByChatRoomId(chatRoomId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_CHAT_ROOM)
         );
     }
@@ -58,7 +58,7 @@ public class ChatRoomService {
         );
     }
 
-    private String getChatRoomId(String createdGitHubId, String receiveGitHubId) {
+    private String generateChatRoomId(String createdGitHubId, String receiveGitHubId) {
         long createdGitHubIdAsLong = Long.parseLong(createdGitHubId);
         long receiveGitHubIdAsLong = Long.parseLong(receiveGitHubId);
 

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,53 @@
+package com.twoclock.gitconnect.domain.chat.service;
+
+import com.twoclock.gitconnect.domain.chat.entity.ChatRoom;
+import com.twoclock.gitconnect.domain.chat.repository.ChatRoomRepository;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void createChatRoom(String createdGitHubId, String receiveGitHubId) {
+        Member createdMember = validateMember(createdGitHubId);
+        Member receiveMember = validateMember(receiveGitHubId);
+
+        String chatRoomId = validateChatRoom(createdMember, receiveMember);
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .chatRoomId(chatRoomId)
+                .createdMember(createdMember)
+                .receivedMember(receiveMember)
+                .build();
+
+        chatRoomRepository.save(chatRoom);
+    }
+
+    private Member validateMember(String createdGitHubId) {
+        return memberRepository.findByGitHubId(createdGitHubId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
+        );
+    }
+
+    private String validateChatRoom(Member createdMember, Member receiveMember) {
+        long minMemberId = Math.min(createdMember.getId(), receiveMember.getId());
+        long maxMemberId = Math.max(createdMember.getId(), receiveMember.getId());
+
+        String chatRoomId = minMemberId + ":" + maxMemberId;
+
+        if (chatRoomRepository.existsByChatRoomId(chatRoomId)) {
+            throw new CustomException(ErrorCode.ALREADY_EXIST_CHAT_ROOM);
+        }
+        return chatRoomId;
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
@@ -16,6 +16,8 @@ import java.util.Arrays;
 @Service
 public class ChatRoomService {
 
+    private static final String CHATROOM_DELIMITER = "-";
+
     private final ChatRoomRepository chatRoomRepository;
     private final MemberRepository memberRepository;
 
@@ -62,7 +64,7 @@ public class ChatRoomService {
 
         long minMemberId = Math.min(createdGitHubIdAsLong, receiveGitHubIdAsLong);
         long maxMemberId = Math.max(createdGitHubIdAsLong, receiveGitHubIdAsLong);
-        String chatRoomId = minMemberId + ":" + maxMemberId;
+        String chatRoomId = minMemberId + CHATROOM_DELIMITER + maxMemberId;
 
         if (chatRoomRepository.existsByChatRoomId(chatRoomId)) {
             throw new CustomException(ErrorCode.ALREADY_EXIST_CHAT_ROOM);
@@ -71,7 +73,7 @@ public class ChatRoomService {
     }
 
     private void checkAccessChatRoom(String githubId, String chatRoomId) {
-        boolean isCheck = Arrays.asList(chatRoomId.split(":")).contains(githubId);
+        boolean isCheck = Arrays.asList(chatRoomId.split(CHATROOM_DELIMITER)).contains(githubId);
         if (!isCheck) {
             throw new CustomException(ErrorCode.NO_ACCESS_CHAT_ROOM);
         }

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatMessageController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatMessageController.java
@@ -1,0 +1,31 @@
+package com.twoclock.gitconnect.domain.chat.web;
+
+import com.twoclock.gitconnect.domain.chat.dto.ChatMessageSaveReqDto;
+import com.twoclock.gitconnect.domain.chat.dto.ChatMessageSaveRespDto;
+import com.twoclock.gitconnect.domain.chat.service.ChatMessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@RequiredArgsConstructor
+@Controller
+public class ChatMessageController {
+
+    private final ChatMessageService chatMessageService;
+
+    @MessageMapping("/{chatRoomId}")
+    @SendTo("/sub/{chatRoomId}")
+    public ChatMessageSaveRespDto sendMessage(
+            Principal userDetails,
+            @DestinationVariable(value = "chatRoomId") String chatRoomId,
+            @Payload ChatMessageSaveReqDto chatMessageSaveReqDto
+    ) {
+        String gitHubId = userDetails.getName();
+        return chatMessageService.sendMessage(gitHubId, chatRoomId, chatMessageSaveReqDto);
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
@@ -5,10 +5,7 @@ import com.twoclock.gitconnect.global.model.RestResponse;
 import com.twoclock.gitconnect.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/v1/chats")
 @RequiredArgsConstructor
@@ -24,6 +21,16 @@ public class ChatRoomController {
     ) {
         String createdGitHubId = userDetails.getUsername();
         chatRoomService.createChatRoom(createdGitHubId, receiveGitHubId);
+        return RestResponse.OK();
+    }
+
+    @DeleteMapping("/{id}")
+    public RestResponse deleteChatRoom(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("id") Long id
+    ) {
+        String githubId = userDetails.getUsername();
+        chatRoomService.deleteChatRoom(githubId, id);
         return RestResponse.OK();
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/api/v1/chats")
+@RequestMapping("/api/v1/chatrooms")
 @RequiredArgsConstructor
 @RestController
 public class ChatRoomController {

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
@@ -1,0 +1,29 @@
+package com.twoclock.gitconnect.domain.chat.web;
+
+import com.twoclock.gitconnect.domain.chat.service.ChatRoomService;
+import com.twoclock.gitconnect.global.model.RestResponse;
+import com.twoclock.gitconnect.global.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/chats")
+@RequiredArgsConstructor
+@RestController
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @PostMapping
+    public RestResponse createChatRoom(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam("receiveId") String receiveGitHubId
+    ) {
+        String createdGitHubId = userDetails.getUsername();
+        chatRoomService.createChatRoom(createdGitHubId, receiveGitHubId);
+        return RestResponse.OK();
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
@@ -24,13 +24,13 @@ public class ChatRoomController {
         return RestResponse.OK();
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/{chatRoomId}")
     public RestResponse deleteChatRoom(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PathVariable("id") Long id
+            @PathVariable("chatRoomId") String chatRoomId
     ) {
         String githubId = userDetails.getUsername();
-        chatRoomService.deleteChatRoom(githubId, id);
+        chatRoomService.deleteChatRoom(githubId, chatRoomId);
         return RestResponse.OK();
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
@@ -48,12 +48,18 @@ public class WebSecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000"));
+        configuration.setAllowedOrigins(
+                List.of(
+                        "http://localhost:3000", "http://127.0.0.1:3000",
+                        "http://localhost:5500", "http://127.0.0.1:5500"
+                )
+        );
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/api/v1/**", configuration);
+        source.registerCorsConfiguration("/**", configuration);
         return source;
     }
 
@@ -70,6 +76,7 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((requests) -> requests
                         .requestMatchers(HttpMethod.GET, GET_PERMIT_STRINGS).permitAll()
                         .requestMatchers(HttpMethod.POST, POST_PERMIT_STRINGS).permitAll()
+                        .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSocketConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSocketConfig.java
@@ -1,0 +1,36 @@
+package com.twoclock.gitconnect.global.config;
+
+import com.twoclock.gitconnect.global.security.WebSocketPreHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@RequiredArgsConstructor
+@EnableWebSocketMessageBroker
+@Configuration
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketPreHandler webSocketPreHandler;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/pub");
+        registry.enableSimpleBroker("/sub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketPreHandler);
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -30,7 +30,10 @@ public enum ErrorCode {
     NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, "B-003", "해당 게시판을 찾을 수 없습니다."),
 
     DUPLICATED_LIKE(HttpStatus.BAD_REQUEST, "L-001", "이미 좋아요를 누른 게시글입니다."),
-    NOT_FOUND_LIKE(HttpStatus.BAD_REQUEST, "L-002", "좋아요를 누른 게시글을 찾을 수 없습니다.");
+    NOT_FOUND_LIKE(HttpStatus.BAD_REQUEST, "L-002", "좋아요를 누른 게시글을 찾을 수 없습니다."),
+
+    ALREADY_EXIST_CHAT_ROOM(HttpStatus.CONFLICT, "CH-001", "이미 존재하는 채팅방입니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
     NOT_FOUND_LIKE(HttpStatus.BAD_REQUEST, "L-002", "좋아요를 누른 게시글을 찾을 수 없습니다."),
 
     ALREADY_EXIST_CHAT_ROOM(HttpStatus.CONFLICT, "CH-001", "이미 존재하는 채팅방입니다."),
+    NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "CH-002", "찾을 수 없는 채팅방입니다."),
+    NO_ACCESS_CHAT_ROOM(HttpStatus.BAD_REQUEST, "CH-003", "접근할 수 없는 채팅방입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/twoclock/gitconnect/global/security/WebSocketPreHandler.java
+++ b/src/main/java/com/twoclock/gitconnect/global/security/WebSocketPreHandler.java
@@ -1,0 +1,87 @@
+package com.twoclock.gitconnect.global.security;
+
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.jwt.service.JwtRedisService;
+import com.twoclock.gitconnect.global.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.twoclock.gitconnect.global.exception.constants.ErrorCode.JWT_BLACKLIST;
+import static com.twoclock.gitconnect.global.exception.constants.ErrorCode.JWT_EXPIRED;
+import static com.twoclock.gitconnect.global.jwt.service.JwtService.BEARER_PREFIX;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebSocketPreHandler implements ChannelInterceptor {
+
+    private final JwtService jwtService;
+    private final JwtRedisService jwtRedisService;
+    private final UserDetailsServiceImpl userDetailsServiceImpl;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        StompCommand command = Objects.requireNonNull(accessor).getCommand();
+
+        if (isCommandToSkip(command)) {
+            return message;
+        }
+
+        if (Objects.equals(command, StompCommand.ERROR)) {
+            throw new MessageDeliveryException("Error during WebSocket communication");
+        }
+
+        String authorizationHeader = getAuthorizationHeader(accessor);
+        if (isValidToken(authorizationHeader)) {
+            String jwtAccessToken = authorizationHeader.substring(BEARER_PREFIX.length());
+            validateToken(jwtAccessToken);
+
+            String login = jwtService.getGitHubId(jwtAccessToken);
+            UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(login);
+
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+            accessor.setUser(authenticationToken);
+        }
+        return message;
+    }
+
+    private boolean isCommandToSkip(StompCommand command) {
+        return command == StompCommand.UNSUBSCRIBE || command == StompCommand.MESSAGE ||
+                command == StompCommand.CONNECTED || command == StompCommand.SEND;
+    }
+
+    private String getAuthorizationHeader(StompHeaderAccessor accessor) {
+        List<String> authorizationHeader = accessor.getNativeHeader(HttpHeaders.AUTHORIZATION);
+        return (authorizationHeader != null && !authorizationHeader.isEmpty()) ? authorizationHeader.get(0) : "";
+    }
+
+    private boolean isValidToken(String authorizationHeader) {
+        return authorizationHeader.startsWith(BEARER_PREFIX);
+    }
+
+    private void validateToken(String jwtAccessToken) {
+        if (!jwtService.validateToken(jwtAccessToken)) {
+            throw new CustomException(JWT_EXPIRED);
+        }
+        if (jwtRedisService.isBlacklisted(jwtAccessToken)) {
+            throw new CustomException(JWT_BLACKLIST);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈

* #58, #59 

## 변경 사항

- 1대1 채팅 생성 기능을 추가 했습니다.
  - `POST /api/v1/chatrooms?receiveId={receiveGitHubId}`
  - 채팅방 고유 ID를 따로 설정해줬습니다. (채팅 만든 회원의 GitHub ID - 채팅 대상 회원의 GitHub ID)
  - 채팅방 중복 생성을 방지했습니다.
  - 채팅 시 메세지 내용 저장은 NoSQL DB 인 MongoDB 를 이용했습니다.
    - 다양한 형태의 정보를 유연하게 저장하고 빠르게 처리할 수 있습니다.
    - 데이터가 많아져도 쉽게 확장할 수 있고, 실시간 처리가 잘 됩니다.
- 1대1 채팅 삭제 기능을 추가했습니다.
  - `DELETE /api/v1/chatrooms/{chatRoomId}`
  - Soft Delete 를 적용했습니다.
- Docker Compose 에 MongoDB 를 추가했습니다.
- application.yml 에 MongoDB 관련된 내용이 추가됐습니다.
```yml
spring:
  data:
    mongodb:
      uri: mongodb://root:1234@localhost:27017/chat
```

<img width="1728" alt="스크린샷 2024-08-21 오후 7 55 14" src="https://github.com/user-attachments/assets/17e2dc5e-0d7a-459d-9843-b9782152073f">
<img width="1198" alt="스크린샷 2024-08-21 오후 8 04 37" src="https://github.com/user-attachments/assets/189b4f76-2602-41d9-beab-d2bc9842fdaa">

## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?

## MongoDB 초기 설정 명령어
```sql
use chat;

db.createCollection("messages");

db.createUser({
    user: "root",
    pwd: "1234",
    roles: [{role: "readWrite", db: "chat"}]
});

db.grantRolesToUser("root", [{role: "readWrite", db: "chat"}]);
```