### PR TITLE
faet:  Add commenting and profanity filtering to boards

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // 욕설 필터 라이브러리
+    implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentRegReqDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentRegReqDto.java
@@ -1,0 +1,14 @@
+package com.twoclock.gitconnect.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CommentRegReqDto(
+        @NotNull(message = "게시판 키가 존재하지 않습니다.")
+        Long boardId,
+        @Size(max = 50, message = "댓글은 50자 이내로 작성해주세요.")
+        @NotBlank(message = "내용을 입력해주세요.")
+        String content
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentRegistReqDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentRegistReqDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record CommentRegReqDto(
+public record CommentRegistReqDto(
         @NotNull(message = "게시판 키가 존재하지 않습니다.")
         Long boardId,
         @Size(max = 50, message = "댓글은 50자 이내로 작성해주세요.")

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentRegistReqDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentRegistReqDto.java
@@ -5,8 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CommentRegistReqDto(
-        @NotNull(message = "게시판 키가 존재하지 않습니다.")
-        Long boardId,
         @Size(max = 50, message = "댓글은 50자 이내로 작성해주세요.")
         @NotBlank(message = "내용을 입력해주세요.")
         String content

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/entity/Comment.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/entity/Comment.java
@@ -8,12 +8,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@DynamicUpdate
 @SQLDelete(sql = "UPDATE comment SET is_view = false WHERE id = ?")
 @Where(clause = "is_view = true")
 public class Comment extends BaseEntity {
@@ -37,14 +39,13 @@ public class Comment extends BaseEntity {
     private String content;
 
     @Column(nullable = false)
-    private boolean isView = true;
+    private final boolean isView = true;
 
     @Builder
-    public Comment(Board board, Member member, String nickname, String content, boolean isView) {
+    public Comment(Board board, Member member, String nickname, String content) {
         this.board = board;
         this.member = member;
         this.nickname = nickname;
         this.content = content;
-        this.isView = isView;
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -2,7 +2,7 @@ package com.twoclock.gitconnect.domain.comment.service;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
-import com.twoclock.gitconnect.domain.comment.dto.CommentRegReqDto;
+import com.twoclock.gitconnect.domain.comment.dto.CommentRegistReqDto;
 import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
@@ -23,7 +23,7 @@ public class CommentService {
     private final BoardRepository boardRepository;
 
     @Transactional
-    public void saveComment(CommentRegReqDto dto, String githubId) {
+    public void saveComment(CommentRegistReqDto dto, String githubId) {
         filteringBadWord(dto.content());
         Board board = validateBoard(dto.boardId());
         Member member = validateMember(githubId);

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -1,12 +1,49 @@
 package com.twoclock.gitconnect.domain.comment.service;
 
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
+import com.twoclock.gitconnect.domain.comment.dto.CommentRegReqDto;
+import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public void saveComment(CommentRegReqDto dto, String githubId) {
+        Board board = validateBoard(dto.boardId());
+        Member member = validateMember(githubId);
+
+        Comment comment = Comment.builder()
+                .board(board)
+                .member(member)
+                .nickname(member.getName())
+                .content(dto.content())
+                .build();
+        commentRepository.save(comment);
+    }
+
+    private Board validateBoard(Long boardId) {
+        return boardRepository.findById(boardId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_BOARD)
+        );
+    }
+
+    private Member validateMember(String githubId) {
+        return memberRepository.findByGitHubId(githubId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
+        );
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -9,6 +9,7 @@ import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import com.vane.badwordfiltering.BadWordFiltering;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ public class CommentService {
 
     @Transactional
     public void saveComment(CommentRegReqDto dto, String githubId) {
+        filteringBadWord(dto.content());
         Board board = validateBoard(dto.boardId());
         Member member = validateMember(githubId);
 
@@ -45,5 +47,12 @@ public class CommentService {
         return memberRepository.findByGitHubId(githubId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
         );
+    }
+
+    private void filteringBadWord(String content) {
+        BadWordFiltering filtering = new BadWordFiltering();
+        if (filtering.check(content)) {
+            throw new CustomException(ErrorCode.BAD_WORD);
+        }
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -23,9 +23,9 @@ public class CommentService {
     private final BoardRepository boardRepository;
 
     @Transactional
-    public void saveComment(CommentRegistReqDto dto, String githubId) {
+    public void saveComment(CommentRegistReqDto dto, String githubId, Long boardId) {
         filteringBadWord(dto.content());
-        Board board = validateBoard(dto.boardId());
+        Board board = validateBoard(boardId);
         Member member = validateMember(githubId);
 
         Comment comment = Comment.builder()

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
@@ -1,6 +1,6 @@
 package com.twoclock.gitconnect.domain.comment.web;
 
-import com.twoclock.gitconnect.domain.comment.dto.CommentRegReqDto;
+import com.twoclock.gitconnect.domain.comment.dto.CommentRegistReqDto;
 import com.twoclock.gitconnect.domain.comment.service.CommentService;
 import com.twoclock.gitconnect.global.model.RestResponse;
 import jakarta.validation.Valid;
@@ -20,7 +20,7 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping
-    public RestResponse saveComment(@RequestBody @Valid CommentRegReqDto dto,
+    public RestResponse saveComment(@RequestBody @Valid CommentRegistReqDto dto,
                                     @AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails.getUsername();
         commentService.saveComment(dto, githubId);

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
@@ -7,23 +7,21 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/comments")
+@RequestMapping("/api/v1")
 @RestController
 public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping
+    @PostMapping("/boards/{boardId}/comment")
     public RestResponse saveComment(@RequestBody @Valid CommentRegistReqDto dto,
+                                    @PathVariable("boardId") Long boardId,
                                     @AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails.getUsername();
-        commentService.saveComment(dto, githubId);
+        commentService.saveComment(dto, githubId, boardId);
         return RestResponse.OK();
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
@@ -1,6 +1,14 @@
 package com.twoclock.gitconnect.domain.comment.web;
 
+import com.twoclock.gitconnect.domain.comment.dto.CommentRegReqDto;
+import com.twoclock.gitconnect.domain.comment.service.CommentService;
+import com.twoclock.gitconnect.global.model.RestResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/comments")
 @RestController
 public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public RestResponse saveComment(@RequestBody @Valid CommentRegReqDto dto,
+                                    @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        commentService.saveComment(dto, githubId);
+        return RestResponse.OK();
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -30,7 +30,9 @@ public enum ErrorCode {
     NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, "B-003", "해당 게시판을 찾을 수 없습니다."),
 
     DUPLICATED_LIKE(HttpStatus.BAD_REQUEST, "L-001", "이미 좋아요를 누른 게시글입니다."),
-    NOT_FOUND_LIKE(HttpStatus.BAD_REQUEST, "L-002", "좋아요를 누른 게시글을 찾을 수 없습니다.");
+    NOT_FOUND_LIKE(HttpStatus.BAD_REQUEST, "L-002", "좋아요를 누른 게시글을 찾을 수 없습니다."),
+
+    BAD_WORD(HttpStatus.BAD_REQUEST, "W-001", "금지어가 포함되어 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 관련 이슈

* #53 

## 변경 사항
게시글에 대해서 댓글을 추가할 수 있는 API 도입하였습니다.
> API : `api/v1/comments`

**Request**
```
{
    "boardId" : 1,
    "content" : "테스트 내용입니다."
}
```

-> `content` 필드에 비속어가 포함될 경우 필터링 되어 사용자에게 반환 처리 됩니다.
```
{
    "code": "W-001",
    "message": "금지어가 포함되어 있습니다.",
    "errors": null
}
```
[비속어 관련 라이브러리](https://github.com/VaneProject/bad-word-filtering)


## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?