### PR TITLE
feat: Add pagination for chat messages endpoint

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatMessageRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatMessageRespDto.java
@@ -1,0 +1,10 @@
+package com.twoclock.gitconnect.domain.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageRespDto(
+        String login,
+        String message,
+        LocalDateTime createdDateTime
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,11 @@
 package com.twoclock.gitconnect.domain.chat.repository;
 
 import com.twoclock.gitconnect.domain.chat.entity.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+
+    Page<ChatMessage> findAllByChatRoomId(String chatId, Pageable pageable);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
@@ -54,7 +54,7 @@ public class ChatRoomService {
 
     @Transactional(readOnly = true)
     public List<ChatMessageRespDto> chatRoomMessages(String githubId, String chatRoomId, int page, int size) {
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdDateTime");
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.ASC, "createdDateTime");
 
         Member member = validateMemberByGitHubId(githubId);
         ChatRoom chatRoom = validateChatRoomById(chatRoomId);

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
@@ -1,16 +1,21 @@
 package com.twoclock.gitconnect.domain.chat.service;
 
+import com.twoclock.gitconnect.domain.chat.dto.ChatMessageRespDto;
 import com.twoclock.gitconnect.domain.chat.entity.ChatRoom;
+import com.twoclock.gitconnect.domain.chat.repository.ChatMessageRepository;
 import com.twoclock.gitconnect.domain.chat.repository.ChatRoomRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -20,6 +25,7 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final MemberRepository memberRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     @Transactional
     public void createChatRoom(String createdGitHubId, String receiveGitHubId) {
@@ -44,6 +50,25 @@ public class ChatRoomService {
 
         checkAccessChatRoom(member.getGitHubId(), chatRoom.getChatRoomId());
         chatRoomRepository.delete(chatRoom);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatMessageRespDto> chatRoomMessages(String githubId, String chatRoomId, int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "createdDateTime");
+
+        Member member = validateMemberByGitHubId(githubId);
+        ChatRoom chatRoom = validateChatRoomById(chatRoomId);
+        checkAccessChatRoom(member.getGitHubId(), chatRoom.getChatRoomId());
+
+        return chatMessageRepository.findAllByChatRoomId(chatRoomId, pageRequest)
+                .getContent()
+                .stream()
+                .map(chatRoomMessage -> new ChatMessageRespDto(
+                        chatRoomMessage.getSenderMember().getLogin(),
+                        chatRoomMessage.getMessage(),
+                        chatRoomMessage.getCreatedDateTime()
+                ))
+                .toList();
     }
 
     private ChatRoom validateChatRoomById(String chatRoomId) {

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
@@ -1,11 +1,14 @@
 package com.twoclock.gitconnect.domain.chat.web;
 
+import com.twoclock.gitconnect.domain.chat.dto.ChatMessageRespDto;
 import com.twoclock.gitconnect.domain.chat.service.ChatRoomService;
 import com.twoclock.gitconnect.global.model.RestResponse;
 import com.twoclock.gitconnect.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequestMapping("/api/v1/chatrooms")
 @RequiredArgsConstructor
@@ -32,5 +35,17 @@ public class ChatRoomController {
         String githubId = userDetails.getUsername();
         chatRoomService.deleteChatRoom(githubId, chatRoomId);
         return RestResponse.OK();
+    }
+
+    @GetMapping("/{chatRoomId}/messages")
+    public RestResponse chatRoomMessages(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("chatRoomId") String chatRoomId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10", required = false) int size
+    ) {
+        String githubId = userDetails.getUsername();
+        List<ChatMessageRespDto> responseDto = chatRoomService.chatRoomMessages(githubId, chatRoomId, page, size);
+        return new RestResponse(responseDto);
     }
 }


### PR DESCRIPTION
## 관련 이슈

* #60

## 변경 사항

- 채팅방에 보낸 메세지들을 확인할 수 있습니다.
  - `GET /api/v1/chatrooms/{chatRoomId}/messages?page=0&size=10` (size 는 필수 항목이 아닙니다)
  - 페이지네이션을 적용시켰습니다.
  - 보낸일자 기준으로 내림차순 정렬을 시켰습니다.
- 채팅방에 참여 인원이 아닐 시 `CH-003` 에러가 나타납니다.
```json
{
    "code": "CH-003",
    "message": "접근할 수 없는 채팅방입니다.",
    "errors": null
}
```

### response
```json
{
    "message": "OK",
    "data": [
        {
            "login": "openmpy",
            "message": "에잉",
            "createdDateTime": "2024-08-22T02:11:05.859"
        },
        {
            "login": "openmpy",
            "message": "이잉",
            "createdDateTime": "2024-08-22T02:11:05.221"
        },
        {
            "login": "openmpy",
            "message": "이잉",
            "createdDateTime": "2024-08-22T02:11:04.529"
        },
        {
            "login": "openmpy",
            "message": "이이이이",
            "createdDateTime": "2024-08-22T02:11:03.844"
        },
        {
            "login": "openmpy",
            "message": "이잉",
            "createdDateTime": "2024-08-22T02:11:03.06"
        },
        {
            "login": "openmpy",
            "message": "아에이",
            "createdDateTime": "2024-08-22T02:11:02.435"
        },
        {
            "login": "openmpy",
            "message": "q",
            "createdDateTime": "2024-08-22T02:09:28.708"
        },
        {
            "login": "openmpy",
            "message": "o",
            "createdDateTime": "2024-08-22T02:09:27.333"
        },
        {
            "login": "openmpy",
            "message": "m",
            "createdDateTime": "2024-08-22T02:09:26.642"
        },
        {
            "login": "openmpy",
            "message": "n",
            "createdDateTime": "2024-08-22T02:09:26.07"
        }
    ]
}
```

## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?