### PR TITLE
feat: Add ChatRoomRepository query, and getChatRooms endpoint

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatRoomRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/dto/ChatRoomRespDto.java
@@ -1,0 +1,11 @@
+package com.twoclock.gitconnect.domain.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomRespDto(
+        String login,
+        String avatarUrl,
+        String lastMessage,
+        LocalDateTime createdDateTime
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatMessageRepository.java
@@ -5,7 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Optional;
+
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
 
     Page<ChatMessage> findAllByChatRoomId(String chatId, Pageable pageable);
+
+    Optional<ChatMessage> findFirstByChatRoomIdOrderByCreatedDateTimeDesc(String chatRoomId);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, CustomChatRoomRepository {
 
     boolean existsByChatRoomId(String chatRoomId);
 

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepositoryImpl.java
@@ -25,7 +25,6 @@ public class ChatRoomRepositoryImpl implements CustomChatRoomRepository {
                 .where(chatRoom.createdMember.eq(member)
                         .or(chatRoom.receivedMember.eq(member))
                 )
-                .orderBy(chatRoom.createdDateTime.desc())
                 .groupBy(chatRoom.id)
                 .fetch();
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/repository/ChatRoomRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.twoclock.gitconnect.domain.chat.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twoclock.gitconnect.domain.chat.entity.ChatRoom;
+import com.twoclock.gitconnect.domain.chat.entity.QChatRoom;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class ChatRoomRepositoryImpl implements CustomChatRoomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ChatRoomRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<ChatRoom> findUniqueChatRoomsByMember(Member member) {
+        QChatRoom chatRoom = QChatRoom.chatRoom;
+        return queryFactory.selectFrom(chatRoom)
+                .where(chatRoom.createdMember.eq(member)
+                        .or(chatRoom.receivedMember.eq(member))
+                )
+                .orderBy(chatRoom.createdDateTime.desc())
+                .groupBy(chatRoom.id)
+                .fetch();
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/repository/CustomChatRoomRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/repository/CustomChatRoomRepository.java
@@ -1,0 +1,11 @@
+package com.twoclock.gitconnect.domain.chat.repository;
+
+import com.twoclock.gitconnect.domain.chat.entity.ChatRoom;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+
+import java.util.List;
+
+public interface CustomChatRoomRepository {
+
+    List<ChatRoom> findUniqueChatRoomsByMember(Member member);
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatRoomService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -61,6 +62,7 @@ public class ChatRoomService {
 
         return chatRooms.stream()
                 .map(chatRoom -> getChatRoomDetails(chatRoom, githubId))
+                .sorted(Comparator.comparing(ChatRoomRespDto::createdDateTime).reversed())
                 .toList();
     }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/web/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.twoclock.gitconnect.domain.chat.web;
 
 import com.twoclock.gitconnect.domain.chat.dto.ChatMessageRespDto;
+import com.twoclock.gitconnect.domain.chat.dto.ChatRoomRespDto;
 import com.twoclock.gitconnect.domain.chat.service.ChatRoomService;
 import com.twoclock.gitconnect.global.model.RestResponse;
 import com.twoclock.gitconnect.global.security.UserDetailsImpl;
@@ -35,6 +36,15 @@ public class ChatRoomController {
         String githubId = userDetails.getUsername();
         chatRoomService.deleteChatRoom(githubId, chatRoomId);
         return RestResponse.OK();
+    }
+
+    @GetMapping
+    public RestResponse getChatRooms(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        String githubId = userDetails.getUsername();
+        List<ChatRoomRespDto> responseDto = chatRoomService.getChatRooms(githubId);
+        return new RestResponse(responseDto);
     }
 
     @GetMapping("/{chatRoomId}/messages")

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -4,7 +4,6 @@ import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
-import com.twoclock.gitconnect.domain.member.entity.constants.Role;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
@@ -13,7 +12,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+
+import static com.twoclock.gitconnect.domain.member.entity.constants.Role.ROLE_USER;
 
 @Slf4j
 @Configuration
@@ -27,20 +29,17 @@ public class DummyDevlnit {
             log.info("Dummy Data Init");
 
             // 테스트 계정 생성
-            Member member = Member.builder()
-                    .login("loginId")
-                    .gitHubId("1234")
-                    .avatarUrl("/uploads/profile/test.jpg")
-                    .name("테스트 유저")
-                    .role(Role.ROLE_USER)
-                    .build();
-            memberRepository.save(member);
+            List<Member> members = Arrays.asList(
+                    new Member("loginId-1", "1234", "/uploads/profile/test1.jpg", "테스트 유저 1", ROLE_USER),
+                    new Member("loginId-2", "5678", "/uploads/profile/test2.jpg", "테스트 유저 2", ROLE_USER)
+            );
+            memberRepository.saveAll(members);
 
             // 테스트 게시글 생성
             List<Board> boards = new ArrayList<>();
-            createDummyBoards(boards, "계정 홍보 테스트 게시글", Category.BD1, 10, member);
-            createDummyBoards(boards, "저장소 홍보 테스트 게시글", Category.BD2, 10, member);
-            createDummyBoards(boards, "사용자 신고 테스트 게시글", Category.BD3, 10, member);
+            createDummyBoards(boards, "계정 홍보 테스트 게시글", Category.BD1, 10, members.get(0));
+            createDummyBoards(boards, "저장소 홍보 테스트 게시글", Category.BD2, 10, members.get(0));
+            createDummyBoards(boards, "사용자 신고 테스트 게시글", Category.BD3, 10, members.get(0));
             boardRepository.saveAll(boards);
         };
     }

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -35,7 +35,6 @@ public enum ErrorCode {
     ALREADY_EXIST_CHAT_ROOM(HttpStatus.CONFLICT, "CH-001", "이미 존재하는 채팅방입니다."),
     NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "CH-002", "찾을 수 없는 채팅방입니다."),
     NO_ACCESS_CHAT_ROOM(HttpStatus.BAD_REQUEST, "CH-003", "접근할 수 없는 채팅방입니다."),
-    NOT_FOUND_FIRST_CHAT_MESSAGE(HttpStatus.NOT_FOUND, "CH-004", "첫번째 채팅 메세지를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     ALREADY_EXIST_CHAT_ROOM(HttpStatus.CONFLICT, "CH-001", "이미 존재하는 채팅방입니다."),
     NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "CH-002", "찾을 수 없는 채팅방입니다."),
     NO_ACCESS_CHAT_ROOM(HttpStatus.BAD_REQUEST, "CH-003", "접근할 수 없는 채팅방입니다."),
+    NOT_FOUND_FIRST_CHAT_MESSAGE(HttpStatus.NOT_FOUND, "CH-004", "첫번째 채팅 메세지를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 관련 이슈

* #60 

## 변경 사항

- 더미 데이터에 멤버 부분을 리스트 형식으로 변경 했습니다.
- 채팅방 목록 기능을 추가했습니다.
  - `GET /api/v1/chatrooms`
  - 조회 시 `상대방 아이디, 프로필 URL, 마지막 대화, 마지막 대화 생성 일자`를 내려줬습니다.
  - Querydsl 을 이용해서 `ID 기준으로 중복되는 채팅방`을 필터링 해줬습니다.
  - 채팅 메세지의 `createdDateTime` 기준으로 내림차순 정렬을 했습니다.
- polling 방식을 생각하고 구현 했습니다.
  - 추후 프론트가 완성 된다면 소켓 방식으로 변경할 예정입니다.

```json
{
    "message": "OK",
    "data": [
        {
            "login": "loginId-2",
            "avatarUrl": "/uploads/profile/test2.jpg",
            "lastMessage": "하하",
            "createdDateTime": "2024-08-23T17:00:37.016"
        },
        {
            "login": "loginId-1",
            "avatarUrl": "/uploads/profile/test1.jpg",
            "lastMessage": "안녕하세요",
            "createdDateTime": "2024-08-23T17:00:25.243"
        }
    ]
}
```

## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?