### PR TITLE
feat: add delete comment API

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -47,6 +47,14 @@ public class CommentService {
         comment.update(dto.content());
     }
 
+    @Transactional
+    public void deleteComment(String githubId, Long commentId) {
+        Member member = validateMember(githubId);
+        Comment comment = validateComment(commentId);
+
+        commentRepository.delete(comment);
+    }
+
     private Board validateBoard(Long boardId) {
         return boardRepository.findById(boardId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_BOARD)

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
@@ -34,4 +34,12 @@ public class CommentController {
         commentService.modifyComment(dto, githubId, commentId);
         return RestResponse.OK();
     }
+
+    @DeleteMapping("/comments/{commentId}")
+    public RestResponse deleteComment(@PathVariable("commentId") Long commentId,
+                                      @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        commentService.deleteComment(githubId, commentId);
+        return RestResponse.OK();
+    }
 }


### PR DESCRIPTION
## 관련 이슈

* #55 

## 변경 사항
등록한 댓글에 대해서 삭제할 수 있는 기능 추가
-> 데이터의 완전한 삭제가 아닌 조회 여부 컬럼 update(soft delete)
> API : `/api/v1/comments/{commentId} [Put 요청]
![image](https://github.com/user-attachments/assets/b016a4dd-b7d6-49f2-9b10-e7fdb1433d45)
* IS_VIEW 컬럼에 대해서 UPDATE 확인


## 체크 목록
- [X] 포스트맨으로 체크해 보았나요?
