### PR TITLE
refactor: boards API refactor and get data with comment and likes

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardRequestDto.java
@@ -19,8 +19,6 @@ public class BoardRequestDto {
     }
 
     public record BoardModifyReqDto(
-            @NotNull(message = "게시판 키가 존재하지 않습니다.")
-            Long id,
             @Size(max = 50, message = "제목은 50자 이내로 작성해주세요.")
             @NotBlank(message = "제목을 입력해주세요.")
             String title,

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchResponseDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchResponseDto.java
@@ -11,17 +11,22 @@ public record SearchResponseDto(
         String content,
         String nickname,
         String category,
-        MemberLoginRespDto member
+        MemberLoginRespDto member,
+        Long commentCount,
+        Long likeCount
 ) {
 
     @QueryProjection
-    public SearchResponseDto(Long id, String title, String content, String nickname, String category, MemberLoginRespDto member) {
+    public SearchResponseDto(Long id, String title, String content, String nickname, String category,
+                             MemberLoginRespDto member, Long commentCount, Long likeCount) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.nickname = nickname;
         this.category = category;
         this.member = member;
+        this.commentCount = commentCount;
+        this.likeCount = likeCount;
     }
 }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -12,6 +12,7 @@ import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import com.vane.badwordfiltering.BadWordFiltering;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -28,6 +29,7 @@ public class BoardService {
 
     @Transactional
     public BoardRespDto saveBoard(BoardSaveReqDto boardSaveReqDto, String githubId) {
+        filteringBadWord(boardSaveReqDto.content());
         Member member = validateMember(githubId);
         Category code = Category.of(boardSaveReqDto.category());
 
@@ -44,6 +46,7 @@ public class BoardService {
 
     @Transactional
     public BoardRespDto modifyBoard(BoardModifyReqDto boardUpdateReqDto, Long boardId, String githubId) {
+        filteringBadWord(boardUpdateReqDto.content());
         Member member = validateMember(githubId);
         Board board = validateBoard(boardId);
         board.checkUserId(member.getId());
@@ -51,7 +54,6 @@ public class BoardService {
 
         return new BoardRespDto(board);
     }
-
 
     @Transactional(readOnly = true)
     public Page<SearchResponseDto> getBoardList(SearchRequestDto searchRequestDto) {
@@ -67,7 +69,6 @@ public class BoardService {
         Page<SearchResponseDto> boardList = boardRepository.searchBoardList(searchRequestDto, pageRequest);
 
         return boardList;
-
     }
 
     @Transactional
@@ -89,5 +90,12 @@ public class BoardService {
         return boardRepository.findById(boardId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_BOARD)
         );
+    }
+
+    private void filteringBadWord(String content) {
+        BadWordFiltering filtering = new BadWordFiltering();
+        if (filtering.check(content)) {
+            throw new CustomException(ErrorCode.BAD_WORD);
+        }
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -10,6 +10,8 @@ import com.twoclock.gitconnect.global.model.RestResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -20,44 +22,35 @@ public class BoardController {
     private final BoardService boardService;
 
     @PostMapping
-    public RestResponse saveBoard(@RequestBody @Valid BoardSaveReqDto boardSaveReqDto) {
-        // TODO : 로그인 유저인지 검증 필요
-        Long userId = 1L;
-
-        BoardRespDto boardRespDto = boardService.saveBoard(boardSaveReqDto, userId);
-
+    public RestResponse saveBoard(@RequestBody @Valid BoardSaveReqDto boardSaveReqDto,
+                                  @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        BoardRespDto boardRespDto = boardService.saveBoard(boardSaveReqDto, githubId);
         return RestResponse.OK();
-//        return new RestResponse(boardRespDto);
     }
 
-    @PutMapping
-    public RestResponse updateBoard(@RequestBody @Valid BoardModifyReqDto boardUpdateReqDto) {
-        // TODO : 로그인 유저인지 검증 필요
-        Long userId = 1L;
-
-        BoardRespDto boardRespDto = boardService.modifyBoard(boardUpdateReqDto, userId);
-
+    @PutMapping("/{boardId}")
+    public RestResponse updateBoard(@RequestBody @Valid BoardModifyReqDto boardUpdateReqDto,
+                                    @PathVariable("boardId") Long boardId,
+                                    @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        BoardRespDto boardRespDto = boardService.modifyBoard(boardUpdateReqDto, boardId, githubId);
         return RestResponse.OK();
-//        return new RestResponse(boardRespDto);
     }
 
 
     @GetMapping
     public RestResponse getBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto) {
-
         Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto);
-
         return new RestResponse(boardRespDto);
 
     }
 
-    @DeleteMapping("/{boardKey}")
-    public RestResponse deleteBoard(@PathVariable("boardKey") Long boardKey) {
-        // TODO : 로그인 유저인지 검증 필요
-        Long userId = 1L;
-
-        boardService.deleteBoard(boardKey, userId);
-
+    @DeleteMapping("/{boardId}")
+    public RestResponse deleteBoard(@PathVariable("boardId") Long boardId,
+                                    @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        boardService.deleteBoard(boardId, githubId);
         return RestResponse.OK();
 
     }

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -3,6 +3,8 @@ package com.twoclock.gitconnect.global.dummy;
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
+import com.twoclock.gitconnect.domain.comment.entity.Comment;
+import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +26,9 @@ public class DummyDevlnit {
     // 프로덕트 출시 전에 개발자들이 사용할 더미 데이터를 초기화하는 클래스
     @Profile("local")
     @Bean
-    CommandLineRunner init(MemberRepository memberRepository, BoardRepository boardRepository) {
+    CommandLineRunner init(MemberRepository memberRepository,
+                           BoardRepository boardRepository,
+                           CommentRepository commentRepository) {
         return (args) -> {
             log.info("Dummy Data Init");
 
@@ -41,6 +45,11 @@ public class DummyDevlnit {
             createDummyBoards(boards, "저장소 홍보 테스트 게시글", Category.BD2, 10, members.get(0));
             createDummyBoards(boards, "사용자 신고 테스트 게시글", Category.BD3, 10, members.get(0));
             boardRepository.saveAll(boards);
+
+            // 테스트 댓글 생성
+            List<Comment> comments = new ArrayList<>();
+            createDummyComments(comments, 5, members.get(0), boards.get(0));
+            commentRepository.saveAll(comments);
         };
     }
 
@@ -55,6 +64,19 @@ public class DummyDevlnit {
                     .category(category)
                     .build();
             boards.add(board);
+        }
+    }
+
+    private void createDummyComments(List<Comment> comments, int count,
+                                     Member member, Board board) {
+        for (int i = 0; i < count; i++) {
+            Comment comment = Comment.builder()
+                    .board(board)
+                    .member(member)
+                    .nickname(member.getName())
+                    .content("테스트 댓글 입니다 " + i)
+                    .build();
+            comments.add(comment);
         }
     }
 


### PR DESCRIPTION
## 관련 이슈

* #65 

## 변경 사항

* 게시판 Business Layer 검증 로직 Method로 분리(사용자 및 게시글)
* 댓글 더미 데이터 생성(5건)
* 게시글 작성 및 수정 시 비속어 필터링 적용
* 게시글 검색 시 댓글 수, 좋아요 수 함께 조회
> ![image](https://github.com/user-attachments/assets/cf63decc-7046-4535-9c48-e3eae3baa1f9)


## 체크 목록

- [ ] 포스트맨으로 체크해 보았나요?
- [ ] 테스트 코드를 작성 하셨나요?