### PR TITLE
feat: add API to view comments on boards

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentListRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentListRespDto.java
@@ -1,0 +1,11 @@
+package com.twoclock.gitconnect.domain.comment.dto;
+
+public record CommentListRespDto(
+        Long id,
+        Long memberId,
+        String avatarUrl,
+        String nickname,
+        String content,
+        String createdAt
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentListRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentListRespDto.java
@@ -1,11 +1,27 @@
 package com.twoclock.gitconnect.domain.comment.dto;
 
+import com.twoclock.gitconnect.domain.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+
 public record CommentListRespDto(
         Long id,
         Long memberId,
         String avatarUrl,
         String nickname,
         String content,
-        String createdAt
+        LocalDateTime modifiedDateTime,
+        LocalDateTime createdDateTime
 ) {
+    public CommentListRespDto(Comment comment) {
+        this(
+                comment.getId(),
+                comment.getMember().getId(),
+                comment.getMember().getAvatarUrl(),
+                comment.getNickname(),
+                comment.getContent(),
+                comment.getModifiedDateTime(),
+                comment.getCreatedDateTime()
+        );
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,11 @@
 package com.twoclock.gitconnect.domain.comment.repository;
 
+import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByBoard(Board board);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package com.twoclock.gitconnect.domain.comment.service;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
+import com.twoclock.gitconnect.domain.comment.dto.CommentListRespDto;
 import com.twoclock.gitconnect.domain.comment.dto.CommentModifyReqDto;
 import com.twoclock.gitconnect.domain.comment.dto.CommentRegistReqDto;
 import com.twoclock.gitconnect.domain.comment.entity.Comment;
@@ -14,6 +15,8 @@ import com.vane.badwordfiltering.BadWordFiltering;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -53,6 +56,15 @@ public class CommentService {
         Comment comment = validateComment(commentId);
 
         commentRepository.delete(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentListRespDto> getComments(Long boardId) {
+        Board board = validateBoard(boardId);
+        List<Comment> comments = commentRepository.findAllByBoard(board);
+        return comments.stream()
+                .map(CommentListRespDto::new)
+                .toList();
     }
 
     private Board validateBoard(Long boardId) {

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/web/CommentController.java
@@ -1,5 +1,6 @@
 package com.twoclock.gitconnect.domain.comment.web;
 
+import com.twoclock.gitconnect.domain.comment.dto.CommentListRespDto;
 import com.twoclock.gitconnect.domain.comment.dto.CommentModifyReqDto;
 import com.twoclock.gitconnect.domain.comment.dto.CommentRegistReqDto;
 import com.twoclock.gitconnect.domain.comment.service.CommentService;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
@@ -41,5 +44,11 @@ public class CommentController {
         String githubId = userDetails.getUsername();
         commentService.deleteComment(githubId, commentId);
         return RestResponse.OK();
+    }
+
+    @GetMapping("/boards/{boardId}/comments")
+    public RestResponse getComments(@PathVariable("boardId") Long boardId) {
+        List<CommentListRespDto> result = commentService.getComments(boardId);
+        return new RestResponse(result);
     }
 }


### PR DESCRIPTION
## 관련 이슈

* #56 

## 변경 사항
* 게시글의 대해서 댓글을 조회할 수 있는 API 추가
> API : `/api/v1/boards/{boardId}/comments`

**Response**
```
{
    "message": "OK",
    "data": [
        {
            "id": 1,
            "memberId": 3,
            "avatarUrl": "https://avatars.githubusercontent.com/u/103441154?v=4",
            "nickname": "짱스키",
            "content": "댓글 1",
            "modifiedDateTime": null,
            "createdDateTime": "2024-08-25T23:19:23.389284"
        },
        {
            "id": 2,
            "memberId": 3,
            "avatarUrl": "https://avatars.githubusercontent.com/u/103441154?v=4",
            "nickname": "짱스키",
            "content": "댓글 2",
            "modifiedDateTime": null,
            "createdDateTime": "2024-08-25T23:19:28.074806"
        },
        {
            "id": 3,
            "memberId": 3,
            "avatarUrl": "https://avatars.githubusercontent.com/u/103441154?v=4",
            "nickname": "짱스키",
            "content": "이게 가장 최신 댓글",
            "modifiedDateTime": null,
            "createdDateTime": "2024-08-25T23:19:33.430515"
        }
    ]
}
```

## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?