### PR TITLE
feat: Add Monitoring with Prometheus and Grafana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ application-local.yml
 ### Docker ###
 mysql-data/
 mongodb-data/
+grafana-data/
+prometheus/*.log

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ dependencies {
 
     // 욕설 필터 라이브러리
     implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
+
+    // 모니터링
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/compose.yml
+++ b/compose.yml
@@ -29,3 +29,27 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=1234
     volumes:
       - ./mongodb-data:/data
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    restart: always
+    ports:
+      - 9090:9090
+    command:
+      - '--web.enable-lifecycle'
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    volumes:
+      - ./prometheus:/etc/prometheus
+    extra_hosts:
+      host.docker.internal: host-gateway
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:latest
+    restart: always
+    ports:
+      - 3000:3000
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana-data:/var/lib/grafana
+      - ./grafana-data/provisioning/:/etc/grafana/provisioning/

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    monitor: 'gitconnect-monitor'
+  query_log_file: query_log_file.log
+
+scrape_configs:
+  - job_name: "spring-actuator"
+    metrics_path: "/actuator/prometheus"
+    scrape_interval: 1s
+    static_configs:
+      - targets: [ "host.docker.internal:8090" ]

--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
@@ -76,7 +76,7 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((requests) -> requests
                         .requestMatchers(HttpMethod.GET, GET_PERMIT_STRINGS).permitAll()
                         .requestMatchers(HttpMethod.POST, POST_PERMIT_STRINGS).permitAll()
-                        .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers("/ws/**", "/actuator/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 관련 이슈

* #63 

## 변경 사항

- 액츄에이터 & 프로메테우스 & 그라파나 연동 작업을 진행 했습니다.
  - 액츄에이터: `http://localhost:8090/actuator`
  - 프로메테우스: `http://localhost:9090`
  - 그라파나: `http://localhost:3000`
    - 아이디: `admin`, 비밀번호: `admin`
    
## 추후 작업
- 개발 단계이기 때문에 모든 계정이 접근 가능하도록 설정 했습니다.
- 추후에 어드민 계정만 접근 가능하도록 설정 할 예정입니다.
- 서비스가 얼추 완성 된다면 메트릭을 수집해서 좀 더 디테일하게 모니터링 작업을 진행할 예정입니다. 
    
## 그라파나 대쉬보드 연동 방법
1. `http://localhost:3000` 접속 하시면 로그인 하라는 화면이 뜹니다.
2. 아이디: `admin`, 비밀번호: `admin` 을 적고 로그인을 해줍니다.
3. `Update your password` 창이 뜬다면 입력폼 왼쪽 하단에 `Skip` 을 눌러줍니다.
4. 왼쪽 상단에 `메뉴 > Connections > Data sources` 버튼을 눌러줍니다.
5. 화면 중앙에 `Add data source` 버튼을 눌러줍니다.
6. `Prometeus` 를 선택해줍니다.
7. `Connection` 입력창에 `http://prometheus:9090` 을 입력해주고 쭉 내려서 `Save & test` 버튼을 눌러줍니다.
8. 정상적으로 연결이 됐다면 `메뉴 > Dashboards` 버튼을 눌러줍니다.
9. 오른쪽 상단에 `New` 버튼을 누르고 `Import` 를 선택합니다.
10. `URL or ID` 입력창에 `4701` 또는 `11378`을 입력하고 `Load` 버튼을 눌러줍니다.
11. 7번 과정에서 생성했던 `프로메테우스`와 연동 시켜줍니다.
12. 연동이 정상적으로 됐다면 아래와 같은 화면이 뜹니다.
<img width="1728" alt="스크린샷 2024-08-28 오후 3 38 03" src="https://github.com/user-attachments/assets/1e363e1f-06b3-4e0f-80c5-eeee9fa803ea">

https://openmpy.tistory.com/221

## 확인 목록
- `http://localhost:9090/targets` 에서 `state` 가 `UP` 상태여야 합니다.
<img width="1728" alt="스크린샷 2024-08-28 오후 3 44 19" src="https://github.com/user-attachments/assets/2be4f53b-0edd-4105-8eab-63d5dd997bab">

### application.yml
```yml
management:
  endpoint:
    health:
      show-components: always
  #      show-details: always
  endpoints:
    web:
      exposure:
        include: "*"
  info:
    java:
      enabled: true
    os:
      enabled: true
    env:
      enabled: true
    git:
      mode: full
  server:
    port: 8090
```

---

안되신다면 편하게 말씀 주세요 ~