### PR TITLE
feat: Report  board viewing rights and boards creation delay

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardCacheDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardCacheDto.java
@@ -1,0 +1,23 @@
+package com.twoclock.gitconnect.domain.board.dto;
+
+import com.twoclock.gitconnect.domain.board.entity.Board;
+
+public record BoardCacheDto (
+        Long id,
+        String title,
+        String content,
+        String category,
+        String gitHubId,
+        String createdAt
+){
+    public BoardCacheDto(Board board) {
+        this(
+                board.getId(),
+                board.getTitle(),
+                board.getContent(),
+                board.getCategory().name(),
+                board.getMember().getGitHubId(),
+                board.getCreatedDateTime().toString()
+        );
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchRequestDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchRequestDto.java
@@ -21,8 +21,8 @@ public record SearchRequestDto(
         return PageRequest.of(pageNumber, pageSize);
     }
 
-    public void changeForReportSearch(String category, String githubId, String role) {
-        new SearchRequestDto(githubId, role, word, type, category, page, size);
+    public SearchRequestDto changeUseMember(String githubId, String role) {
+        return new SearchRequestDto(githubId, role, word, type, category, page, size);
     }
 
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchRequestDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/SearchRequestDto.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.domain.PageRequest;
 
 public record SearchRequestDto(
+
+        String githubId,
+        String role,
         String word,
         String type, // 검색 조건(제목, 내용, 작성자)
         @NotBlank(message = "카테고리는 필수값 입니다.")
@@ -16,6 +19,10 @@ public record SearchRequestDto(
         int pageNumber = (page != null) ? page.intValue() : 0;
         int pageSize = (size != null) ? size.intValue() : 10;
         return PageRequest.of(pageNumber, pageSize);
+    }
+
+    public void changeForReportSearch(String category, String githubId, String role) {
+        new SearchRequestDto(githubId, role, word, type, category, page, size);
     }
 
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardCacheRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardCacheRepository.java
@@ -1,0 +1,23 @@
+package com.twoclock.gitconnect.domain.board.repository;
+
+import com.twoclock.gitconnect.domain.board.dto.BoardCacheDto;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+public class BoardCacheRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public BoardCacheRepository(RedisTemplate<String, Object> redisTemplate){
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void setBoardCache(String key, BoardCacheDto boardCacheDto) {
+        redisTemplate.opsForValue().set(key, boardCacheDto, Duration.ofMinutes(5));
+    }
+    public BoardCacheDto getBoardCache(String key) {
+        return (BoardCacheDto) redisTemplate.opsForValue().get(key);
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
@@ -8,9 +8,11 @@ import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.member.dto.QMemberLoginRespDto;
+import com.twoclock.gitconnect.domain.member.entity.constants.Role;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -60,9 +62,12 @@ public class BoardRepositoryImpl implements CustomBoardRepository {
 
     private BooleanBuilder searchQueryBuilder(SearchRequestDto searchRequestDto) {
         BooleanBuilder builder = new BooleanBuilder();
+        Category category = Category.of(searchRequestDto.category());
+        Role role = Role.of(searchRequestDto.role());
+        if(role == null) role = Role.ROLE_USER;
 
         // 게시판 카테고리 설정
-        builder.and(board.category.eq(Category.of(searchRequestDto.category())));
+        builder.and(board.category.eq(category));
 
         // 검색어가 존재하는 경우
         if (searchRequestDto.word() != null) {
@@ -84,6 +89,9 @@ public class BoardRepositoryImpl implements CustomBoardRepository {
                     );
                     break;
             }
+        }
+        if(category.equals(Category.BD3) && !Role.ROLE_ADMIN.equals(role)) {
+            builder.and(board.member.gitHubId.eq(searchRequestDto.githubId()));
         }
 
         return builder;

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepositoryImpl.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.querydsl.core.types.ExpressionUtils.count;
 import static com.twoclock.gitconnect.domain.board.entity.QBoard.board;
@@ -63,8 +64,8 @@ public class BoardRepositoryImpl implements CustomBoardRepository {
     private BooleanBuilder searchQueryBuilder(SearchRequestDto searchRequestDto) {
         BooleanBuilder builder = new BooleanBuilder();
         Category category = Category.of(searchRequestDto.category());
-        Role role = Role.of(searchRequestDto.role());
-        if(role == null) role = Role.ROLE_USER;
+        String roleStr = Optional.ofNullable(searchRequestDto.role()).orElse("ROLE_USER");
+        Role role = Role.of(roleStr);
 
         // 게시판 카테고리 설정
         builder.and(board.category.eq(category));
@@ -90,6 +91,7 @@ public class BoardRepositoryImpl implements CustomBoardRepository {
                     break;
             }
         }
+        // 신고 게시판인 경우 추가 조건처리
         if(category.equals(Category.BD3) && !Role.ROLE_ADMIN.equals(role)) {
             builder.and(board.member.gitHubId.eq(searchRequestDto.githubId()));
         }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -37,7 +37,7 @@ public class BoardService {
         Category code = Category.of(boardSaveReqDto.category());
         String key = "board:" + githubId + ":" + code;
 
-//        validateManyRequestBoard(key);
+        validateManyRequestBoard(key);
         filteringBadWord(boardSaveReqDto.content());
         Member member = validateMember(githubId);
 

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -8,9 +8,9 @@ import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
+import com.twoclock.gitconnect.domain.board.repository.BoardCacheRepository;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
-import com.twoclock.gitconnect.domain.member.entity.constants.Role;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
@@ -30,7 +30,7 @@ public class BoardService {
 
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final BoardCacheRepository boardCacheRepository;
 
     @Transactional
     public BoardRespDto saveBoard(BoardSaveReqDto boardSaveReqDto, String githubId) {
@@ -49,7 +49,7 @@ public class BoardService {
                 .member(member)
                 .build();
         Board boardPS = boardRepository.save(board);
-        redisTemplate.opsForValue().set(key, new BoardCacheDto(boardPS));
+        boardCacheRepository.setBoardCache(key, new BoardCacheDto(boardPS));
         return new BoardRespDto(boardPS);
     }
 
@@ -93,7 +93,7 @@ public class BoardService {
     }
 
     private void validateManyRequestBoard(String key) {
-        BoardCacheDto boardCacheDto = (BoardCacheDto) redisTemplate.opsForValue().get(key);
+        BoardCacheDto boardCacheDto = boardCacheRepository.getBoardCache(key);
         if (boardCacheDto != null){
             LocalDateTime now = LocalDateTime.now();
             LocalDateTime registerTime = LocalDateTime.parse(boardCacheDto.createdAt());

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -18,7 +18,6 @@ import com.vane.badwordfiltering.BadWordFiltering;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -65,18 +65,17 @@ public class BoardService {
 
     @Transactional(readOnly = true)
     public Page<SearchResponseDto> getBoardList(SearchRequestDto searchRequestDto) {
-
-        // TODO: 카테고리 타입 확인
-
-        // TODO: 신고 게시판 정책 추가
-
-        //
-
-        // 페이지 요청 객체 생성
         PageRequest pageRequest = searchRequestDto.toPageRequest();
-        Page<SearchResponseDto> boardList = boardRepository.searchBoardList(searchRequestDto, pageRequest);
+        return  boardRepository.searchBoardList(searchRequestDto, pageRequest);
+    }
 
-        return boardList;
+    @Transactional(readOnly = true)
+    public Page<SearchResponseDto> getReportBoardList(SearchRequestDto searchRequestDto, String githubId) {
+        Member member = validateMember(githubId);
+        String role = member.getRole().toString();
+        searchRequestDto.changeForReportSearch(Category.BD3.toString(), githubId, role);
+        PageRequest pageRequest = searchRequestDto.toPageRequest();
+        return boardRepository.searchBoardList(searchRequestDto, pageRequest);
     }
 
     @Transactional

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -43,9 +43,7 @@ public class BoardController {
     @GetMapping
     public RestResponse getBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto,
                                      @AuthenticationPrincipal UserDetails userDetails) {
-        String githubId = Optional.ofNullable(userDetails)
-                .map(UserDetails::getUsername)
-                .orElse("");
+        String githubId = userDetails == null ? null : userDetails.getUsername();
         Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto, githubId);
         return new RestResponse(boardRespDto);
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -14,6 +14,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/boards")
 @RestController
@@ -39,16 +41,12 @@ public class BoardController {
     }
 
     @GetMapping
-    public RestResponse getBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto) {
-        Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto);
-        return new RestResponse(boardRespDto);
-    }
-
-    @GetMapping("/report")
-    public RestResponse getReportBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto,
-                                           @AuthenticationPrincipal UserDetails userDetails) {
-        String githubId = userDetails.getUsername();
-        Page<SearchResponseDto> boardRespDto = boardService.getReportBoardList(searchRequestDto, githubId);
+    public RestResponse getBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto,
+                                     @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = Optional.ofNullable(userDetails)
+                .map(UserDetails::getUsername)
+                .orElse("");
+        Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto, githubId);
         return new RestResponse(boardRespDto);
     }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -38,12 +38,18 @@ public class BoardController {
         return RestResponse.OK();
     }
 
-
     @GetMapping
     public RestResponse getBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto) {
         Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto);
         return new RestResponse(boardRespDto);
+    }
 
+    @GetMapping("/report")
+    public RestResponse getReportBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto,
+                                           @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        Page<SearchResponseDto> boardRespDto = boardService.getReportBoardList(searchRequestDto, githubId);
+        return new RestResponse(boardRespDto);
     }
 
     @DeleteMapping("/{boardId}")

--- a/src/main/java/com/twoclock/gitconnect/domain/member/entity/constants/Role.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/entity/constants/Role.java
@@ -1,6 +1,18 @@
 package com.twoclock.gitconnect.domain.member.entity.constants;
 
+import com.twoclock.gitconnect.domain.board.entity.constants.Category;
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+
 public enum Role {
 
-    ROLE_ADMIN, ROLE_USER
+    ROLE_ADMIN, ROLE_USER;
+
+    public static Role of(String role) {
+        try {
+            return Role.valueOf(role);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.NOT_FOUND_ROLE);
+        }
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
@@ -29,7 +29,10 @@ public class WebSecurityConfig {
 
     private static final String[] GET_PERMIT_STRINGS = {
             "api/v1/hello",
-            "/api/v1/members/auth/github/callback"
+            "/api/v1/members/auth/github/callback",
+            "/api/v1/boards",
+            "/api/v1/boards/*/comments",
+            "/api/v1/likes/*"
     };
     private static final String[] POST_PERMIT_STRINGS = {
             "/api/v1/members/auth/refresh"

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "U-001", "잘못된 요청입니다."),
     NOT_ACCEPTABLE(HttpStatus.NOT_ACCEPTABLE, "U-002", "요청을 수락할 수 없습니다."),
 
+    NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "R-001", "찾을 수 없는 권한입니다."),
+
     JWT_ERROR(HttpStatus.UNAUTHORIZED, "JWT-001", "JWT 토큰 에러가 발생했습니다."),
     JWT_REFRESH_TOKEN_ERROR(HttpStatus.FORBIDDEN, "JWT-002", "JWT 리프레쉬 토큰 에러가 발생했습니다."),
     JWT_BLACKLIST(HttpStatus.FORBIDDEN, "JWT-003", "블랙 리스트에 저장된 JWT 토큰입니다."),

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     FAIL_MODIFY_BOARD(HttpStatus.INTERNAL_SERVER_ERROR, "B-002", "게시글 수정에 실패하였습니다."),
     NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, "B-003", "해당 게시판을 찾을 수 없습니다."),
     MANY_SAVE_REQUEST_BOARD(HttpStatus.TOO_MANY_REQUESTS, "B-004", "게시글은 5분에 1번 작성할 수 있습니다."),
+    NOT_USING_REPORT_BOARD(HttpStatus.FORBIDDEN, "B-005", "신고 게시판은 로그인 이후 이용하실 수 있습니다."),
 
     DUPLICATED_LIKE(HttpStatus.BAD_REQUEST, "L-001", "이미 좋아요를 누른 게시글입니다."),
     NOT_FOUND_LIKE(HttpStatus.BAD_REQUEST, "L-002", "좋아요를 누른 게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     FAIL_SAVE_BOARD(HttpStatus.INTERNAL_SERVER_ERROR, "B-001", "게시글 저장에 실패하였습니다."),
     FAIL_MODIFY_BOARD(HttpStatus.INTERNAL_SERVER_ERROR, "B-002", "게시글 수정에 실패하였습니다."),
     NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, "B-003", "해당 게시판을 찾을 수 없습니다."),
+    MANY_SAVE_REQUEST_BOARD(HttpStatus.TOO_MANY_REQUESTS, "B-004", "게시글은 5분에 1번 작성할 수 있습니다."),
 
     DUPLICATED_LIKE(HttpStatus.BAD_REQUEST, "L-001", "이미 좋아요를 누른 게시글입니다."),
     NOT_FOUND_LIKE(HttpStatus.BAD_REQUEST, "L-002", "좋아요를 누른 게시글을 찾을 수 없습니다."),


### PR DESCRIPTION
## 관련 이슈
* #72 

## 변경 사항
> **도배성 게시글을 방지하기 위한 게시글 작성 후 5분 뒤 추가 작성 가능 로직 추가**

연속 작성 시, 해당 Exception 반환 처리
```
{
    "code": "B-004",
    "message": "게시글은 5분에 1번 작성할 수 있습니다.",
    "errors": null
}
```
-> 각 카테고리 별로 제한을 두었으며 계정 홍보 게시판(BD1) 작성 후 저장소 홍보 게시판(BD2) 게시글 연속 작성 가능

> **신고 게시판 로직 추가**
- 신고 게시글은 본인이 신고한 게시글만 조회할 수 있음
- 관리자는 모든 신고 게시글을 조회할 수 있다.

**유저 권한으로 조회**
-> 본인이 작성한 게시글만 조회됨

![image](https://github.com/user-attachments/assets/68286f50-d914-4b42-88f3-aba67ac7cfce)

**권한으로 조회**
-> 전체 신고 게시글 조회 가능

![image](https://github.com/user-attachments/assets/fb514797-ae27-4550-b2c8-ddf113f17af2)



## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?
