### PR TITLE
feat: Image file deletion processing when editing or deleting a boards

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardRequestDto.java
@@ -1,8 +1,9 @@
 package com.twoclock.gitconnect.domain.board.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import java.util.List;
 
 public class BoardRequestDto {
 
@@ -23,8 +24,8 @@ public class BoardRequestDto {
             @NotBlank(message = "제목을 입력해주세요.")
             String title,
             @NotBlank(message = "내용을 입력해주세요.")
-            String content
-
+            String content,
+            List<String> fileOriginImageList
     ) {
 
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
@@ -57,7 +57,7 @@ public class Board extends BaseEntity {
 
     // 게시판 작성 본인 검증 Method
     public void checkUserId(Long userKey) {
-        if (userKey.longValue() != this.id.longValue()) {
+        if (userKey.longValue() != this.member.getId().longValue()) {
             throw new CustomException(ErrorCode.DIFF_USER_BOARD);
         }
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardFileRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardFileRepository.java
@@ -3,5 +3,8 @@ package com.twoclock.gitconnect.domain.board.repository;
 import com.twoclock.gitconnect.domain.board.entity.BoardFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardFileRepository extends JpaRepository<BoardFile, Long> {
+    List<BoardFile> findByBoardId(Long boardId);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -27,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -41,9 +42,7 @@ public class BoardService {
     private final S3Service s3Service;
 
     private static final int MAX_BOARD_IMAGE_SIZE = 5 * 1024 * 1024;
-    private static final List<String> PERMIT_BOARD_IMAGE_TYPE = List.of(
-            "image/jpeg", "image/jpg", "image/png"
-    );
+    private static final List<String> PERMIT_BOARD_IMAGE_TYPE = List.of("image/jpeg", "image/jpg", "image/png");
 
     @Transactional
     public BoardRespDto saveBoard(BoardSaveReqDto boardSaveReqDto, String githubId, MultipartFile[] files) {
@@ -75,8 +74,7 @@ public class BoardService {
         Board board = validateBoard(boardId);
         board.checkUserId(member.getId());
 
-        List<BoardFile> boardFiles = boardFileRepository.findByBoardId(boardId);
-        deleteBoardImage(boardFiles, boardUpdateReqDto.fileOriginImageList());
+        deleteBoardImage(boardId, boardUpdateReqDto.fileOriginImageList());
 
         if (files.length != 0) boardImageUpload(files, board);
         board.updateBoard(boardUpdateReqDto.title(), boardUpdateReqDto.content());
@@ -96,20 +94,16 @@ public class BoardService {
         Member member = validateMember(githubId);
         Board board = validateBoard(boardId);
         board.checkUserId(member.getId());
+        deleteBoardImage(boardId, new ArrayList<>());
         boardRepository.delete(board);
-
     }
 
     private Member validateMember(String githubId) {
-        return memberRepository.findByGitHubId(githubId).orElseThrow(
-                () -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)
-        );
+        return memberRepository.findByGitHubId(githubId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
     private Board validateBoard(Long boardId) {
-        return boardRepository.findById(boardId).orElseThrow(
-                () -> new CustomException(ErrorCode.NOT_FOUND_BOARD)
-        );
+        return boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_BOARD));
     }
 
     private void validateManyRequestBoard(String key) {
@@ -142,11 +136,7 @@ public class BoardService {
         for (MultipartFile file : files) {
             String originalName = file.getOriginalFilename();
             String fileUrl = uploadFileUrl(file);
-            BoardFile boardFile = BoardFile.builder()
-                    .board(board)
-                    .originalName(originalName)
-                    .fileUrl(fileUrl)
-                    .build();
+            BoardFile boardFile = BoardFile.builder().board(board).originalName(originalName).fileUrl(fileUrl).build();
             boardFileRepository.save(boardFile);
         }
     }
@@ -171,14 +161,18 @@ public class BoardService {
         }
     }
 
-    private void deleteBoardImage(List<BoardFile> boardFiles, List<String> boardOriginImageList) {
+    private void deleteBoardImage(Long boardId, List<String> boardOriginImageList) {
+        List<BoardFile> boardFiles = boardFileRepository.findByBoardId(boardId);
         if (!boardFiles.isEmpty()) {
-            boardFiles.stream()
-                    .filter(boardFile -> boardOriginImageList.contains(boardFile.getFileUrl()))
-                    .forEach(boardFile -> {
-                        boardFileRepository.delete(boardFile);
-                        s3Service.deleteFile(boardFile.getFileUrl());
-                    });
+            if (boardOriginImageList != null && !boardOriginImageList.isEmpty()) {
+                boardFiles = boardFiles.stream()
+                        .filter(boardFile -> !boardOriginImageList.contains(boardFile.getFileUrl()))
+                        .toList();
+            }
+            boardFiles.forEach(boardFile -> {
+                boardFileRepository.delete(boardFile);
+                s3Service.deleteFile(boardFile.getFileUrl());
+            });
         }
     }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -34,11 +34,12 @@ public class BoardController {
     }
 
     @PutMapping("/{boardId}")
-    public RestResponse updateBoard(@RequestBody @Valid BoardModifyReqDto boardUpdateReqDto,
+    public RestResponse updateBoard(@RequestPart @Valid BoardModifyReqDto boardUpdateReqDto,
                                     @PathVariable("boardId") Long boardId,
+                                    @RequestPart(required = false) MultipartFile[] files,
                                     @AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails.getUsername();
-        BoardRespDto boardRespDto = boardService.modifyBoard(boardUpdateReqDto, boardId, githubId);
+        BoardRespDto boardRespDto = boardService.modifyBoard(boardUpdateReqDto, boardId, githubId, files);
         return RestResponse.OK();
     }
 

--- a/src/main/java/com/twoclock/gitconnect/global/s3/S3Service.java
+++ b/src/main/java/com/twoclock/gitconnect/global/s3/S3Service.java
@@ -32,7 +32,8 @@ public class S3Service {
         return s3Client.getUrl(bucket, keyName).toString();
     }
 
-    public void deleteFile(String keyName) {
+    public void deleteFile(String fileUrl) {
+        String keyName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
         DeleteObjectRequest request = new DeleteObjectRequest(bucket, keyName);
         s3Client.deleteObject(request);
     }


### PR DESCRIPTION
## 관련 이슈

* #79 
* #80

## 변경 사항
> **게시글 수정 시, 파일 변경 확인 후 삭제처리**
![image](https://github.com/user-attachments/assets/d9b05725-dc72-4d1f-928e-ae55a9ad2d50)


이미 게시글의 등록된 3개의 사진 중 뒷 자리가 `..a27b.png` 파일을 제외하고 삭제 후 새로운 파일 을 등록한 경우
![image](https://github.com/user-attachments/assets/37cdda7a-4f99-4182-95df-c942634c1194)
수정 과정에서 파일 2개 삭제 후 파일 1개 새로 등록 완료 
![image](https://github.com/user-attachments/assets/91613e39-93f6-4636-9329-b5b8d05cdb29)
![image](https://github.com/user-attachments/assets/b1be0183-61b2-4bdb-8951-d48d1e1bcedb)
S3에서도 파일 삭제 완료하였습니다.

> **게시글 삭제 시, 파일 일괄 삭제**
`/api/v1/boards/{boardId}` [Delete] 로 동일하게 요청 시 해당 게시글이 갖고 있는 모든 Image File 일괄 삭제 처리
- DB 파일 정보 삭제
- S3 파일 삭제


## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?
