### PR TITLE
feat: add board details view API addition and caching processing

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
@@ -1,17 +1,7 @@
 package com.twoclock.gitconnect.domain.board.dto;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
-import com.twoclock.gitconnect.domain.comment.dto.CommentListRespDto;
-import com.twoclock.gitconnect.domain.comment.entity.Comment;
-import com.twoclock.gitconnect.domain.like.dto.LikesRespDto;
-import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.member.dto.MemberLoginRespDto;
-import org.springframework.data.domain.Page;
-
-import java.util.List;
-
-import static com.twoclock.gitconnect.domain.comment.dto.CommentListRespDto.commentListResult;
-import static com.twoclock.gitconnect.domain.like.dto.LikesRespDto.likesListResult;
 
 public record BoardDetailRespDto(
         Long id,
@@ -19,24 +9,16 @@ public record BoardDetailRespDto(
         String content,
         String nickname,
         String category,
-        MemberLoginRespDto member,
-        Long commentCount,
-        List<CommentListRespDto> commentList,
-        Long likeCount,
-        List<LikesRespDto> likesList
+        MemberLoginRespDto member
 ) {
-    public BoardDetailRespDto(Board board, Page<Comment> comment, Page<Likes> likes) {
+    public BoardDetailRespDto(Board board) {
         this(
                 board.getId(),
                 board.getTitle(),
                 board.getContent(),
                 board.getMember().getName(),
                 board.getCategory().name(),
-                MemberLoginRespDto.of(board.getMember()),
-                comment.getTotalElements(),
-                commentListResult(comment.getContent()),
-                likes.getTotalElements(),
-                likesListResult(likes.getContent())
+                MemberLoginRespDto.of(board.getMember())
         );
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
@@ -1,10 +1,17 @@
 package com.twoclock.gitconnect.domain.board.dto;
 
+import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.comment.dto.CommentListRespDto;
+import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import com.twoclock.gitconnect.domain.like.dto.LikesRespDto;
+import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.member.dto.MemberLoginRespDto;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
+
+import static com.twoclock.gitconnect.domain.comment.dto.CommentListRespDto.commentListResult;
+import static com.twoclock.gitconnect.domain.like.dto.LikesRespDto.likesListResult;
 
 public record BoardDetailRespDto(
         Long id,
@@ -18,4 +25,18 @@ public record BoardDetailRespDto(
         Long likeCount,
         List<LikesRespDto> likesList
 ) {
+    public BoardDetailRespDto(Board board, Page<Comment> comment, Page<Likes> likes) {
+        this(
+                board.getId(),
+                board.getTitle(),
+                board.getContent(),
+                board.getMember().getName(),
+                board.getCategory().name(),
+                MemberLoginRespDto.of(board.getMember()),
+                comment.getTotalElements(),
+                commentListResult(comment.getContent()),
+                likes.getTotalElements(),
+                likesListResult(likes.getContent())
+        );
+    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
@@ -1,0 +1,21 @@
+package com.twoclock.gitconnect.domain.board.dto;
+
+import com.twoclock.gitconnect.domain.comment.dto.CommentListRespDto;
+import com.twoclock.gitconnect.domain.like.dto.LikesRespDto;
+import com.twoclock.gitconnect.domain.member.dto.MemberLoginRespDto;
+
+import java.util.List;
+
+public record BoardDetailRespDto(
+        Long id,
+        String title,
+        String content,
+        String nickname,
+        String category,
+        MemberLoginRespDto member,
+        Long commentCount,
+        List<CommentListRespDto> commentList,
+        Long likeCount,
+        List<LikesRespDto> likesList
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
@@ -46,6 +46,9 @@ public class Board extends BaseEntity {
     @Column(nullable = false)
     private final boolean isView = true;
 
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
     @Builder
     public Board(Member member, String nickname, Category category, String title, String content) {
         this.member = member;
@@ -66,5 +69,9 @@ public class Board extends BaseEntity {
     public void updateBoard(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    public void addViewCount() {
+        this.viewCount++;
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -13,9 +13,7 @@ import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.board.repository.BoardCacheRepository;
 import com.twoclock.gitconnect.domain.board.repository.BoardFileRepository;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
-import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
-import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.like.repository.LikeRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.entity.constants.Role;
@@ -27,7 +25,6 @@ import com.vane.badwordfiltering.BadWordFiltering;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -46,8 +43,6 @@ public class BoardService {
     private final MemberRepository memberRepository;
     private final BoardCacheRepository boardCacheRepository;
     private final BoardFileRepository boardFileRepository;
-    private final CommentRepository commentRepository;
-    private final LikeRepository likeRepository;
     private final S3Service s3Service;
 
     private static final int MAX_BOARD_IMAGE_SIZE = 5 * 1024 * 1024;
@@ -111,11 +106,7 @@ public class BoardService {
             }
         }
         board.addViewCount();
-
-        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdDateTime"));
-        Page<Comment> commentPage = commentRepository.findByBoardId(boardId, pageRequest);
-        Page<Likes> likePage = likeRepository.findByBoardId(boardId, pageRequest);
-        return new BoardDetailRespDto(board, commentPage, likePage);
+        return new BoardDetailRespDto(board);
     }
 
     @Transactional

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -13,8 +13,6 @@ import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.board.repository.BoardCacheRepository;
 import com.twoclock.gitconnect.domain.board.repository.BoardFileRepository;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
-import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
-import com.twoclock.gitconnect.domain.like.repository.LikeRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.entity.constants.Role;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
@@ -23,6 +21,7 @@ import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import com.twoclock.gitconnect.global.s3.S3Service;
 import com.vane.badwordfiltering.BadWordFiltering;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -96,6 +95,7 @@ public class BoardService {
         return boardRepository.searchBoardList(searchRequestDto, pageRequest);
     }
 
+    @Cacheable(value = "getBoardDetail", key = "'board:board-id:' + #boardId", cacheManager = "cacheManager")
     @Transactional
     public BoardDetailRespDto getBoardDetail(Long boardId, String githubId) {
         Board board = validateBoard(boardId);

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -95,7 +95,7 @@ public class BoardService {
         return boardRepository.searchBoardList(searchRequestDto, pageRequest);
     }
 
-    @Cacheable(value = "getBoardDetail", key = "'board:board-id:' + #boardId", cacheManager = "cacheManager")
+    @Cacheable(value = "getBoardDetail", key = "'board:board-id:' + #boardId", cacheManager = "redisCacheManager")
     @Transactional
     public BoardDetailRespDto getBoardDetail(Long boardId, String githubId) {
         Board board = validateBoard(boardId);

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -8,6 +8,7 @@ import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
 import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
 import com.twoclock.gitconnect.domain.board.service.BoardService;
 import com.twoclock.gitconnect.global.model.RestResponse;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -46,7 +47,7 @@ public class BoardController {
 
     @GetMapping
     public RestResponse getBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto,
-                                     @AuthenticationPrincipal UserDetails userDetails) {
+                                     @Nullable @AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails == null ? null : userDetails.getUsername();
         Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto, githubId);
         return new RestResponse(boardRespDto);
@@ -54,7 +55,7 @@ public class BoardController {
 
     @GetMapping("/{boardId}")
     public RestResponse getBoardDetail(@PathVariable("boardId") Long boardId,
-                                       @AuthenticationPrincipal UserDetails userDetails) {
+                                       @Nullable @AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails == null ? null : userDetails.getUsername();
         BoardDetailRespDto result = boardService.getBoardDetail(boardId, githubId);
         return new RestResponse(result);

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -1,5 +1,6 @@
 package com.twoclock.gitconnect.domain.board.web;
 
+import com.twoclock.gitconnect.domain.board.dto.BoardDetailRespDto;
 import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.BoardModifyReqDto;
 import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.BoardSaveReqDto;
 import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.BoardRespDto;
@@ -49,6 +50,14 @@ public class BoardController {
         String githubId = userDetails == null ? null : userDetails.getUsername();
         Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto, githubId);
         return new RestResponse(boardRespDto);
+    }
+
+    @GetMapping("/{boardId}")
+    public RestResponse getBoardDetail(@PathVariable("boardId") Long boardId,
+                                       @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails == null ? null : userDetails.getUsername();
+        BoardDetailRespDto result = boardService.getBoardDetail(boardId, githubId);
+        return new RestResponse(result);
     }
 
     @DeleteMapping("/{boardId}")

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentListRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentListRespDto.java
@@ -3,6 +3,7 @@ package com.twoclock.gitconnect.domain.comment.dto;
 import com.twoclock.gitconnect.domain.comment.entity.Comment;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record CommentListRespDto(
         Long id,
@@ -23,5 +24,11 @@ public record CommentListRespDto(
                 comment.getModifiedDateTime(),
                 comment.getCreatedDateTime()
         );
+    }
+
+    public static List<CommentListRespDto> commentListResult(List<Comment> comments){
+        return comments.stream()
+                .map(CommentListRespDto::new)
+                .toList();
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentListRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/dto/CommentListRespDto.java
@@ -25,10 +25,4 @@ public record CommentListRespDto(
                 comment.getCreatedDateTime()
         );
     }
-
-    public static List<CommentListRespDto> commentListResult(List<Comment> comments){
-        return comments.stream()
-                .map(CommentListRespDto::new)
-                .toList();
-    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/repository/CommentRepository.java
@@ -2,10 +2,14 @@ package com.twoclock.gitconnect.domain.comment.repository;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.comment.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByBoard(Board board);
+
+    Page<Comment> findByBoardId(Long boardId, PageRequest createdDateTime);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/repository/CommentRepository.java
@@ -2,14 +2,10 @@ package com.twoclock.gitconnect.domain.comment.repository;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.comment.entity.Comment;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByBoard(Board board);
-
-    Page<Comment> findByBoardId(Long boardId, PageRequest createdDateTime);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikesRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikesRespDto.java
@@ -23,10 +23,4 @@ public record LikesRespDto(
                 likes.getCreatedDateTime()
         );
     }
-
-    public static List<LikesRespDto> likesListResult(List<Likes> likes){
-        return likes.stream()
-                .map(LikesRespDto::new)
-                .toList();
-    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikesRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikesRespDto.java
@@ -3,6 +3,7 @@ package com.twoclock.gitconnect.domain.like.dto;
 import com.twoclock.gitconnect.domain.like.entity.Likes;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record LikesRespDto(
         Long id,
@@ -21,5 +22,11 @@ public record LikesRespDto(
                 likes.getMember().getGitHubId(),
                 likes.getCreatedDateTime()
         );
+    }
+
+    public static List<LikesRespDto> likesListResult(List<Likes> likes){
+        return likes.stream()
+                .map(LikesRespDto::new)
+                .toList();
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
@@ -3,6 +3,8 @@ package com.twoclock.gitconnect.domain.like.repository;
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,4 +14,6 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
     boolean existsByBoardAndMember(Board board, Member member);
     Optional<Likes> findByBoardAndMember(Board board, Member member);
     List<Likes> findAllByBoard(Board board);
+
+    Page<Likes> findByBoardId(Long boardId, PageRequest createdDateTime);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
@@ -3,8 +3,6 @@ package com.twoclock.gitconnect.domain.like.repository;
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.member.entity.Member;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -15,5 +13,4 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
     Optional<Likes> findByBoardAndMember(Board board, Member member);
     List<Likes> findAllByBoard(Board board);
 
-    Page<Likes> findByBoardId(Long boardId, PageRequest createdDateTime);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberLoginRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/dto/MemberLoginRespDto.java
@@ -1,6 +1,7 @@
 package com.twoclock.gitconnect.domain.member.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import com.twoclock.gitconnect.domain.member.entity.Member;
 
 public record MemberLoginRespDto(
         String login,
@@ -15,6 +16,10 @@ public record MemberLoginRespDto(
         this.gitHubId = gitHubId;
         this.avatarUrl = avatarUrl;
         this.name = name;
+    }
+
+    public static MemberLoginRespDto of(Member member) {
+        return new MemberLoginRespDto(member.getLogin(), member.getGitHubId(), member.getAvatarUrl(), member.getName());
     }
 
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberService.java
@@ -24,7 +24,7 @@ public class MemberService {
     private final GitHubTokenRedisService gitHubTokenRedisService;
     private final GithubAPIService githubAPIService;
 
-    @Cacheable(value = "getMember", key = "'member:github-id:' + #gitHubId", cacheManager = "memberCacheManager")
+    @Cacheable(value = "getMember", key = "'member:github-id:' + #gitHubId", cacheManager = "cacheManager")
     @Transactional(readOnly = true)
     public MemberProfileRespDto getMember(String gitHubId) {
         Member member = validateMember(gitHubId);

--- a/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/member/service/MemberService.java
@@ -24,7 +24,7 @@ public class MemberService {
     private final GitHubTokenRedisService gitHubTokenRedisService;
     private final GithubAPIService githubAPIService;
 
-    @Cacheable(value = "getMember", key = "'member:github-id:' + #gitHubId", cacheManager = "cacheManager")
+    @Cacheable(value = "getMember", key = "'member:github-id:' + #gitHubId", cacheManager = "redisCacheManager")
     @Transactional(readOnly = true)
     public MemberProfileRespDto getMember(String gitHubId) {
         Member member = validateMember(gitHubId);

--- a/src/main/java/com/twoclock/gitconnect/global/config/RedisConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/RedisConfig.java
@@ -31,7 +31,7 @@ public class RedisConfig {
     }
 
     @Bean
-    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
         RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(10))
                 .disableCachingNullValues()

--- a/src/main/java/com/twoclock/gitconnect/global/config/RedisConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/RedisConfig.java
@@ -31,7 +31,7 @@ public class RedisConfig {
     }
 
     @Bean
-    public CacheManager memberCacheManager(RedisConnectionFactory redisConnectionFactory) {
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
         RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(10))
                 .disableCachingNullValues()

--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
@@ -31,6 +31,7 @@ public class WebSecurityConfig {
             "api/v1/hello",
             "/api/v1/members/auth/github/callback",
             "/api/v1/boards",
+            "/api/v1/boards/*",
             "/api/v1/boards/*/comments",
             "/api/v1/likes/*"
     };


### PR DESCRIPTION
## 관련 이슈

* #84 

## 변경 사항
> **게시판 상세조회 API 추가**

API : `/api/v1/boards/{boardId}`   [GET]

**Response**
```
{
    "message": "OK",
    "data": {
        "id": 5,
        "title": "계정 홍보 테스트 게시글4",
        "content": "테스트 게시글 내용4",
        "nickname": "테스트 유저 1",
        "category": "BD1",
        "member": {
            "login": "loginId-1",
            "gitHubId": "1234",
            "avatarUrl": "/uploads/profile/test1.jpg",
            "name": "테스트 유저 1"
        }
    }
}

```
- 게시판 상세보기 또한 전체 조회와 동일하게 신고 게시판의 경우 로그인 필요하며 본인의 게시물만 확인할 수 있습니다.
  - 관리자 계정의 경우 모든 신고게시판 조회 가능
  - 그 외 게시판은 전부 조회 가능(권한 필요X)

- 게시판 상세보기도 Redis를 사용하여 캐싱처리를 하였습니다.
  - 유저 조회에서 사용한 동일한 cacheManager 사용(ttl 10분 설정)


추가적으로 최초 상세 조회 API 설계할 때 게시글의 정보와 좋아요 수, 댓글 수, 좋아요 목록(10명), 댓글 목록(10개)를
전부 반환하려고 하였으나, 좋아요 정보와 댓글 정보는 변경점이 많아 캐싱 처리를 하는데 있어서 효율이 떨어질거라 생각하여
최종적으로 게시글의 정보만 반환하였습니다.

현재 좋아요 목록 조회 및 댓글 목록 조회가 페이징처리가 되어 있지 않아서 추후 이슈 등록 후 다시 작업하겠습니다.

## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?