### PR TITLE
feat: Create endpoint for fetching boards by category

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardWithCategoryRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardWithCategoryRespDto.java
@@ -1,0 +1,13 @@
+package com.twoclock.gitconnect.domain.board.dto;
+
+import java.time.LocalDateTime;
+
+public record BoardWithCategoryRespDto(
+        Long id,
+        String title,
+        String content,
+        String login,
+        String thumbnailUrl,
+        LocalDateTime createdDateTime
+) {
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardFileRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardFileRepository.java
@@ -1,10 +1,14 @@
 package com.twoclock.gitconnect.domain.board.repository;
 
+import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.entity.BoardFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BoardFileRepository extends JpaRepository<BoardFile, Long> {
     List<BoardFile> findByBoardId(Long boardId);
+
+    Optional<BoardFile> findFirstByBoard(Board board);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepository.java
@@ -1,10 +1,15 @@
 package com.twoclock.gitconnect.domain.board.repository;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.board.entity.constants.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 public interface BoardRepository extends JpaRepository<Board, Long>,
         CustomBoardRepository,
         QuerydslPredicateExecutor<Board> {
+
+    Page<Board> findByCategoryOrderByCreatedDateTimeDesc(Category category, PageRequest pageRequest);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -4,19 +4,19 @@ import com.twoclock.gitconnect.domain.board.dto.BoardDetailRespDto;
 import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.BoardModifyReqDto;
 import com.twoclock.gitconnect.domain.board.dto.BoardRequestDto.BoardSaveReqDto;
 import com.twoclock.gitconnect.domain.board.dto.BoardResponseDto.BoardRespDto;
-import com.twoclock.gitconnect.domain.board.dto.SearchRequestDto;
-import com.twoclock.gitconnect.domain.board.dto.SearchResponseDto;
+import com.twoclock.gitconnect.domain.board.dto.BoardWithCategoryRespDto;
 import com.twoclock.gitconnect.domain.board.service.BoardService;
 import com.twoclock.gitconnect.global.model.RestResponse;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -45,13 +45,14 @@ public class BoardController {
         return RestResponse.OK();
     }
 
-    @GetMapping
-    public RestResponse getBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto,
-                                     @Nullable @AuthenticationPrincipal UserDetails userDetails) {
-        String githubId = userDetails == null ? null : userDetails.getUsername();
-        Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto, githubId);
-        return new RestResponse(boardRespDto);
-    }
+//     TODO: 이걸 Search 기능으로 바꾸기
+//    @GetMapping
+//    public RestResponse getBoardList(@ModelAttribute @Valid SearchRequestDto searchRequestDto,
+//                                     @Nullable @AuthenticationPrincipal UserDetails userDetails) {
+//        String githubId = userDetails == null ? null : userDetails.getUsername();
+//        Page<SearchResponseDto> boardRespDto = boardService.getBoardList(searchRequestDto, githubId);
+//        return new RestResponse(boardRespDto);
+//    }
 
     @GetMapping("/{boardId}")
     public RestResponse getBoardDetail(@PathVariable("boardId") Long boardId,
@@ -59,6 +60,16 @@ public class BoardController {
         String githubId = userDetails == null ? null : userDetails.getUsername();
         BoardDetailRespDto result = boardService.getBoardDetail(boardId, githubId);
         return new RestResponse(result);
+    }
+
+    @GetMapping
+    public RestResponse getBoardListWithCategory(
+            @RequestParam(value = "category") String category,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", required = false, defaultValue = "10") int size
+    ) {
+        List<BoardWithCategoryRespDto> responseDtos = boardService.getBoardListWithCategory(category, page, size);
+        return new RestResponse(responseDtos);
     }
 
     @DeleteMapping("/{boardId}")

--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
@@ -62,7 +62,7 @@ public class WebSecurityConfig {
         );
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
-        configuration.setExposedHeaders(List.of("Authorization"));
+        configuration.setExposedHeaders(List.of("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -41,9 +41,9 @@ public class DummyDevlnit {
 
             // 테스트 게시글 생성
             List<Board> boards = new ArrayList<>();
-            createDummyBoards(boards, "계정 홍보 테스트 게시글", Category.BD1, 10, members.get(0));
-            createDummyBoards(boards, "저장소 홍보 테스트 게시글", Category.BD2, 10, members.get(0));
-            createDummyBoards(boards, "사용자 신고 테스트 게시글", Category.BD3, 10, members.get(0));
+            createDummyBoards(boards, "계정 홍보 테스트 게시글", Category.BD1, 100, members.get(0));
+            createDummyBoards(boards, "저장소 홍보 테스트 게시글", Category.BD2, 100, members.get(0));
+            createDummyBoards(boards, "사용자 신고 테스트 게시글", Category.BD3, 100, members.get(0));
             boardRepository.saveAll(boards);
 
             // 테스트 댓글 생성


### PR DESCRIPTION
## 관련 이슈

* #90 

## 변경 사항

* 무한 스크롤 구현을 위해서 전체 게시글 불러오는 방식을 수정했습니다.
* 기존에 만들어 두셨던 getBoardList 기능은 검색 기능으로 수정해서 적용하면 될거 같습니다.

![ezgif-3-0e1984b4de](https://github.com/user-attachments/assets/24dfe19c-6209-4194-ba68-9893319d6ab2)


## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?