### PR TITLE
feat: Add view user notifications API

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/notification/dto/NotificationRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/dto/NotificationRespDto.java
@@ -1,0 +1,19 @@
+package com.twoclock.gitconnect.domain.notification.dto;
+
+import com.twoclock.gitconnect.domain.notification.entity.Notification;
+
+import java.time.LocalDateTime;
+
+public record NotificationRespDto(
+        Long id,
+        String message,
+        LocalDateTime createdDateTime
+) {
+    public NotificationRespDto(Notification notification) {
+        this(
+                notification.getId(),
+                notification.getMessage(),
+                notification.getCreatedDateTime()
+        );
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
@@ -1,0 +1,40 @@
+package com.twoclock.gitconnect.domain.notification.entity;
+
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.notification.entity.constants.NotificationType;
+import com.twoclock.gitconnect.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    private String message;
+
+    private boolean isRead = false;
+
+    @Builder
+    public Notification(Member member, NotificationType type, String message, boolean isRead) {
+        this.member = member;
+        this.type = type;
+        this.message = message;
+        this.isRead = isRead;
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
@@ -28,13 +28,12 @@ public class Notification extends BaseEntity {
 
     private String message;
 
-    private boolean isRead = false;
+    private final boolean isRead = false;
 
     @Builder
-    public Notification(Member member, NotificationType type, String message, boolean isRead) {
+    public Notification(Member member, NotificationType type, String message) {
         this.member = member;
         this.type = type;
         this.message = message;
-        this.isRead = isRead;
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/entity/constants/NotificationType.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/entity/constants/NotificationType.java
@@ -1,0 +1,14 @@
+package com.twoclock.gitconnect.domain.notification.entity.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum NotificationType {
+    COMMENT("댓글"),
+    LIKES("좋아요"),
+    CHAT("채팅");
+
+    private final String description;
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.twoclock.gitconnect.domain.notification.repository;
+
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByMemberAndIsReadFalse(Member member);
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -1,0 +1,33 @@
+package com.twoclock.gitconnect.domain.notification.service;
+
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.domain.notification.dto.NotificationRespDto;
+import com.twoclock.gitconnect.domain.notification.entity.Notification;
+import com.twoclock.gitconnect.domain.notification.repository.NotificationRepository;
+import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public List<NotificationRespDto> getNotificationList(String githubId) {
+        Member member = validateMember(githubId);
+        List<Notification> notifications = notificationRepository.findByMemberAndIsReadFalse(member);
+        return notifications.stream().map(NotificationRespDto::new).toList();
+    }
+
+    private Member validateMember(String githubId) {
+        return memberRepository.findByGitHubId(githubId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -10,8 +10,12 @@ import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.async.DeferredResult;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RequiredArgsConstructor
 @Service
@@ -20,14 +24,50 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final MemberRepository memberRepository;
 
+    private final Map<Member, List<DeferredResult<List<NotificationRespDto>>>> waitingUsers = new ConcurrentHashMap<>();
+    private final Long NOTIFY_TIME_OUT = 60000L;
+
     @Transactional(readOnly = true)
-    public List<NotificationRespDto> getNotificationList(String githubId) {
+    public DeferredResult<List<NotificationRespDto>> getNotificationList(String githubId) {
+        DeferredResult<List<NotificationRespDto>> deferredResult = new DeferredResult<>(NOTIFY_TIME_OUT);
+
         Member member = validateMember(githubId);
         List<Notification> notifications = notificationRepository.findByMemberAndIsReadFalse(member);
-        return notifications.stream().map(NotificationRespDto::new).toList();
+        if (!notifications.isEmpty()) {
+            // 새로운 알림이 있으면 바로 응답
+            deferredResult.setResult(toMapNotificationResp(notifications));
+        } else {
+            // 새로운 알림이 없으면 대기 목록에 추가
+            waitingUsers.computeIfAbsent(member, k -> new ArrayList<>()).add(deferredResult);
+        }
+
+        deferredResult.onTimeout(() -> {
+            // 빈 List 반환
+            deferredResult.setResult(new ArrayList<>());
+            removeWaitingUser(member, deferredResult);
+        });
+
+        // 요청이 완료되면 대기 목록에서 제거
+        deferredResult.onCompletion(() -> removeWaitingUser(member, deferredResult));
+
+        return deferredResult;
     }
 
     private Member validateMember(String githubId) {
         return memberRepository.findByGitHubId(githubId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    private List<NotificationRespDto> toMapNotificationResp(List<Notification> notifications) {
+        return notifications.stream().map(NotificationRespDto::new).toList();
+    }
+
+    private void removeWaitingUser(Member member, DeferredResult<List<NotificationRespDto>> deferredResult) {
+        List<DeferredResult<List<NotificationRespDto>>> results = waitingUsers.get(member);
+        if (results != null) {
+            results.remove(deferredResult);
+            if (results.isEmpty()) {
+                waitingUsers.remove(member);
+            }
+        }
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -53,6 +53,16 @@ public class NotificationService {
         return deferredResult;
     }
 
+    // TODO : 댓글, 게시글, 사용자 신고 알림 생성
+    @Transactional
+    public void notifyUser(Member member) {
+        List<Notification> notifications = notificationRepository.findByMemberAndIsReadFalse(member);
+        List<DeferredResult<List<NotificationRespDto>>> userDeferredResults = waitingUsers.remove(member);
+        if (!userDeferredResults.isEmpty()) {
+            userDeferredResults.forEach(r -> r.setResult(toMapNotificationResp(notifications)));
+        }
+    }
+
     private Member validateMember(String githubId) {
         return memberRepository.findByGitHubId(githubId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
@@ -1,0 +1,30 @@
+package com.twoclock.gitconnect.domain.notification.web;
+
+import com.twoclock.gitconnect.domain.notification.dto.NotificationRespDto;
+import com.twoclock.gitconnect.domain.notification.service.NotificationService;
+import com.twoclock.gitconnect.global.model.RestResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notification")
+@RestController
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping()
+    public RestResponse getNotificationList(@AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        List<NotificationRespDto> result = notificationService.getNotificationList(githubId);
+        return new RestResponse(result);
+    }
+
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.DeferredResult;
 
 import java.util.List;
 
@@ -23,7 +24,7 @@ public class NotificationController {
     @GetMapping()
     public RestResponse getNotificationList(@AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails.getUsername();
-        List<NotificationRespDto> result = notificationService.getNotificationList(githubId);
+        DeferredResult<List<NotificationRespDto>> result = notificationService.getNotificationList(githubId);
         return new RestResponse(result);
     }
 

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -90,7 +90,7 @@ public class DummyDevlnit {
     }
 
     private void createDummyNotifications(List<Notification> notifications, int count,
-                                         Member member) {
+                                          Member member) {
         for (int i = 0; i < count; i++) {
             Notification notification = Notification.builder()
                     .member(member)

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -7,6 +7,9 @@ import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.domain.notification.entity.Notification;
+import com.twoclock.gitconnect.domain.notification.entity.constants.NotificationType;
+import com.twoclock.gitconnect.domain.notification.repository.NotificationRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
@@ -28,7 +31,8 @@ public class DummyDevlnit {
     @Bean
     CommandLineRunner init(MemberRepository memberRepository,
                            BoardRepository boardRepository,
-                           CommentRepository commentRepository) {
+                           CommentRepository commentRepository,
+                           NotificationRepository notificationRepository) {
         return (args) -> {
             log.info("Dummy Data Init");
 
@@ -50,6 +54,11 @@ public class DummyDevlnit {
             List<Comment> comments = new ArrayList<>();
             createDummyComments(comments, 5, members.get(0), boards.get(0));
             commentRepository.saveAll(comments);
+
+            // 테스트 알림 생성
+            List<Notification> notification = new ArrayList<>();
+            createDummyNotifications(notification, 5, members.get(0));
+            notificationRepository.saveAll(notification);
         };
     }
 
@@ -77,6 +86,18 @@ public class DummyDevlnit {
                     .content("테스트 댓글 입니다 " + i)
                     .build();
             comments.add(comment);
+        }
+    }
+
+    private void createDummyNotifications(List<Notification> notifications, int count,
+                                         Member member) {
+        for (int i = 0; i < count; i++) {
+            Notification notification = Notification.builder()
+                    .member(member)
+                    .message("테스트 알림 메시지" + i)
+                    .type(NotificationType.CHAT)
+                    .build();
+            notifications.add(notification);
         }
     }
 


### PR DESCRIPTION
## 관련 이슈

* #62 

## 변경 사항
> ** 사용자의 알림 목록 조회 API 추가**
API : `/api/v1/notification` [GET]

알림 조회 부분은 long polling 방식을 사용하였습니다.
원래는 알림 등록 처리까지 마무리 후 Pull Request를 올리려고 했으나
게시판 도메인에서 수정 작업이 빈번하게 생겨 분리하였습니다.
-  등록 관려해서는 #93 으로 분리하였습니다.

**Response**
```
{
    "message": "OK",
    "data": {
        "result": [
            {
                "id": 1,
                "message": "테스트 알림 메시지",
                "createdDateTime": "2024-09-09T23:25:54.521967"
            }
        ],
        "setOrExpired": true
    }
}
```
알림이 정상적으로 반환이 되었다면 `setOrExpired` 값이 `true` 로 반환되며
알림이 없거나 time-out으로 만료가 된 경우에는 `false` 로 반환이 됩니다.


## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?
