### PR TITLE
test: Add dummy data test with Faker library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,9 @@ dependencies {
 
     // aws s3
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.97'
+
+    // Faker
+    implementation 'net.datafaker:datafaker:2.3.1'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/twoclock/gitconnect/data/DummyDataTest.java
+++ b/src/test/java/com/twoclock/gitconnect/data/DummyDataTest.java
@@ -1,0 +1,91 @@
+package com.twoclock.gitconnect.data;
+
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.board.entity.constants.Category;
+import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.entity.constants.Role;
+import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.RepeatedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@SpringBootTest
+class DummyDataTest {
+
+    private static final int MEMBER_DATA_SiZE = 100;
+    private static final int POST_DATA_SIZE = 100_000;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    Faker faker = new Faker(new Locale("ko"));
+
+    @RepeatedTest(100)
+    void dummyData() {
+        List<Member> members = new ArrayList<>();
+        List<Board> boards = new ArrayList<>();
+
+        long startTime = System.currentTimeMillis();
+
+        for (int i = 0; i < MEMBER_DATA_SiZE; i++) {
+            String login = faker.internet().uuid().substring(0, 8);
+            String githubId = faker.internet().uuid().substring(0, 8);
+            String avatarUrl = faker.avatar().image();
+            String name = faker.name().fullName().replace(" ", "");
+
+            Member member = new Member(login, githubId, avatarUrl, name, Role.ROLE_USER);
+            members.add(member);
+        }
+        memberRepository.saveAll(members);
+
+        for (int i = 0; i < POST_DATA_SIZE; i++) {
+            Member member = members.get(faker.number().numberBetween(0, MEMBER_DATA_SiZE - 1));
+            String title = faker.lorem().sentence();
+            String content = faker.lorem().paragraph();
+            Board board = new Board(member, member.getName(), Category.BD1, title, content);
+            boards.add(board);
+        }
+        bulkInsertBoards(boards);
+
+        long endTime = System.currentTimeMillis();
+        System.out.println("소요 시간: " + (endTime - startTime) + "ms");
+    }
+
+    private void bulkInsertBoards(List<Board> boards) {
+        String sql = "INSERT INTO board (member_id, nickname, category, title, content, is_view, view_count, created_date_time) " +
+                "VALUES (?, ?, ?, ?, ?, true, 0, now())";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                Board board = boards.get(i);
+                ps.setLong(1, board.getMember().getId());
+                ps.setString(2, board.getNickname());
+                ps.setString(3, board.getCategory().name());
+                ps.setString(4, board.getTitle());
+                ps.setString(5, board.getContent());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return boards.size();
+            }
+        });
+    }
+}


### PR DESCRIPTION
## 관련 이슈

* #98 

## 변경 사항

* 100명의 회원과 1000만건 게시글 데이터를 넣을 수 있는 기능입니다.
* faker 라이브러리와 jdbc bulk insert 를 사용해서 구현 했습니다.
* 추후에 성능 개선 작업을 할 때 이용하시면 될거 같습니다.

1000만건 기준으로 8분정도 걸립니다.
<img width="294" alt="스크린샷 2024-09-10 오전 10 44 22" src="https://github.com/user-attachments/assets/f98853d4-9a3d-4932-b40e-b26e2c5f00b1">


## 체크 목록

- [x] 테스트 코드를 작성 하셨나요?