### PR TITLE
refactor: when get a boardDetailAPI, images are also viewed

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
@@ -3,22 +3,29 @@ package com.twoclock.gitconnect.domain.board.dto;
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.member.dto.MemberLoginRespDto;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public record BoardDetailRespDto(
         Long id,
         String title,
         String content,
         String nickname,
         String category,
-        MemberLoginRespDto member
+        LocalDateTime createdDateTime,
+        MemberLoginRespDto member,
+        List<BoardFileRespDto> fileList
 ) {
-    public BoardDetailRespDto(Board board) {
+    public BoardDetailRespDto(Board board, List<BoardFileRespDto> fileList) {
         this(
                 board.getId(),
                 board.getTitle(),
                 board.getContent(),
                 board.getMember().getName(),
                 board.getCategory().name(),
-                MemberLoginRespDto.of(board.getMember())
+                board.getCreatedDateTime(),
+                MemberLoginRespDto.of(board.getMember()),
+                fileList
         );
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
@@ -1,5 +1,9 @@
 package com.twoclock.gitconnect.domain.board.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.member.dto.MemberLoginRespDto;
 
@@ -12,7 +16,9 @@ public record BoardDetailRespDto(
         String content,
         String nickname,
         String category,
-        String createdDateTime,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        LocalDateTime createdDateTime,
         MemberLoginRespDto member,
         List<BoardFileRespDto> fileList
 ) {
@@ -23,7 +29,7 @@ public record BoardDetailRespDto(
                 board.getContent(),
                 board.getMember().getName(),
                 board.getCategory().name(),
-                String.valueOf(board.getCreatedDateTime()),
+                board.getCreatedDateTime(),
                 MemberLoginRespDto.of(board.getMember()),
                 fileList
         );

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardDetailRespDto.java
@@ -12,7 +12,7 @@ public record BoardDetailRespDto(
         String content,
         String nickname,
         String category,
-        LocalDateTime createdDateTime,
+        String createdDateTime,
         MemberLoginRespDto member,
         List<BoardFileRespDto> fileList
 ) {
@@ -23,7 +23,7 @@ public record BoardDetailRespDto(
                 board.getContent(),
                 board.getMember().getName(),
                 board.getCategory().name(),
-                board.getCreatedDateTime(),
+                String.valueOf(board.getCreatedDateTime()),
                 MemberLoginRespDto.of(board.getMember()),
                 fileList
         );

--- a/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardFileRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/dto/BoardFileRespDto.java
@@ -1,0 +1,17 @@
+package com.twoclock.gitconnect.domain.board.dto;
+
+import com.twoclock.gitconnect.domain.board.entity.BoardFile;
+
+public record BoardFileRespDto(
+        Long id,
+        String originalName,
+        String fileUrl
+) {
+    public BoardFileRespDto(BoardFile boardFile) {
+        this(
+                boardFile.getId(),
+                boardFile.getOriginalName(),
+                boardFile.getFileUrl()
+        );
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -18,6 +18,7 @@ import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import com.twoclock.gitconnect.global.s3.S3Service;
 import com.vane.badwordfiltering.BadWordFiltering;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -72,6 +73,7 @@ public class BoardService {
         return new BoardRespDto(boardPS);
     }
 
+    @CacheEvict(value = "getBoardDetail", key = "'board:board-id:' + #boardId", cacheManager = "redisCacheManager")
     @Transactional
     public BoardRespDto modifyBoard(BoardModifyReqDto boardUpdateReqDto, Long boardId, String githubId, MultipartFile[] files) {
         filteringBadWord(boardUpdateReqDto.content());
@@ -81,7 +83,9 @@ public class BoardService {
 
         deleteBoardImage(boardId, boardUpdateReqDto.fileOriginImageList());
 
-        if (files.length != 0) boardImageUpload(files, board);
+        if (files != null && files.length != 0) {
+            boardImageUpload(files, board);
+        }
         board.updateBoard(boardUpdateReqDto.title(), boardUpdateReqDto.content());
 
         return new BoardRespDto(board);
@@ -134,6 +138,7 @@ public class BoardService {
                 .toList();
     }
 
+    @CacheEvict(value = "getBoardDetail", key = "'board:board-id:' + #boardId", cacheManager = "redisCacheManager")
     @Transactional
     public void deleteBoard(Long boardId, String githubId) {
         Member member = validateMember(githubId);


### PR DESCRIPTION
## 관련 이슈

* #96 

## 변경 사항

게시글 상세조회 API 요청 시 게시글 등록일 및 사진 이미지 정보 출력

**Response**
```
{
    "message": "OK",
    "data": {
        "id": 301,
        "title": "사진 등록 테스트",
        "content": "수정도 할꺼임 ㅋㅋ",
        "nickname": "짱스키",
        "category": "BD1",
        "createdDateTime": "2024-09-11T00:24:29.360845",   /** 게시글 등록일 추가*/
        "member": {
            "login": "jjangsky",
            "gitHubId": "103441154",
            "avatarUrl": "https://avatars.githubusercontent.com/u/103441154?v=4",
            "name": "짱스키"
        },
        "fileList": [  /** 파일 목록 추가 */
            {
                "id": 1,
                "originalName": "스크린샷 2023-03-29 201201.png",
                "fileUrl": "https://git-************.ap-nort************.amazonaws.com/fbeff8568d1************23bfb86.png"
            },
            {
                "id": 2,
                "originalName": "스크린샷 2023-03-29 201243.png",
                "fileUrl": "https://git-************.ap-north************.amazonaws.com/22185b94526************70bdeb32d62f.png"
            },
            {
                "id": 3,
                "originalName": "스크린샷 2023-03-29 201412.png",
                "fileUrl": "https://git-************.ap-nort************.amazonaws.com/fa462a1e74************da7636379c94b1.png"
            }
        ]
    }
}
```

추가적으로 LocalDateTime 자료형으로 반환하여 응답하려고 했으나 objectMapper 관련하여 LocalDateTime 항목을 직렬화하지 못하는 이슈가 발생하였습니다.
-> record class에서 기본 생성자 정의해서 변환 과정에서 자동으로 objectMapper class가 사용되는것이 아닌가 추측합니다.
이러한 이슈로 임시로 String 형태로 반환하였습니다.
프론트에서 날짜 포맷팅 설정이 필요할 것 같습니다. 
(moment.js 사용하면 날짜 관련하여 지원하는 함수들이 많은 것으로 알고 있습니다.)


## 체크 목록

- [ ] 포스트맨으로 체크해 보았나요?
- [ ] 테스트 코드를 작성 하셨나요?