### PR TITLE
bug: Increased number of views when viewing detailed boards

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/entity/Board.java
@@ -70,8 +70,4 @@ public class Board extends BaseEntity {
         this.title = title;
         this.content = content;
     }
-
-    public void addViewCount() {
-        this.viewCount++;
-    }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/repository/BoardRepository.java
@@ -5,6 +5,7 @@ import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +22,8 @@ public interface BoardRepository extends JpaRepository<Board, Long>,
             @Param("category") Category category,
             Pageable pageable
     );
+
+    @Modifying
+    @Query("UPDATE Board b SET b.viewCount = b.viewCount + 1 WHERE b.id = :boardId")
+    void addViewCount(Long boardId);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/service/BoardService.java
@@ -102,7 +102,7 @@ public class BoardService {
     }
 
     @Cacheable(value = "getBoardDetail", key = "'board:board-id:' + #boardId", cacheManager = "redisCacheManager")
-    @Transactional
+    @Transactional(readOnly = true)
     public BoardDetailRespDto getBoardDetail(Long boardId, String githubId) {
         Board board = validateBoard(boardId);
         List<BoardFileRespDto> fileList = getFileList(boardId);
@@ -113,8 +113,12 @@ public class BoardService {
                 throw new CustomException(ErrorCode.NOT_USING_REPORT_BOARD);
             }
         }
-        board.addViewCount();
         return new BoardDetailRespDto(board, fileList);
+    }
+
+    @Transactional
+    public void addViewCountBoards(Long boardId){
+        boardRepository.addViewCount(boardId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/board/web/BoardController.java
@@ -59,6 +59,7 @@ public class BoardController {
                                        @Nullable @AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails == null ? null : userDetails.getUsername();
         BoardDetailRespDto result = boardService.getBoardDetail(boardId, githubId);
+        boardService.addViewCountBoards(boardId);
         return new RestResponse(result);
     }
 


### PR DESCRIPTION
## 관련 이슈

* #104

## 변경 사항
> 기존의 상세보기 API 요청 시, 하나의 서비스로 상세보기 조회와 조회 수 증가 로직을 두가지 넣다보니
상세보기 데이터가 캐싱되는 경우 조회 수 증가 로직이 실행되지 않는 이슈가 있었습니다.

**상세보기 조회 / 조회 수 증가 서비스 로직 분리**
![image](https://github.com/user-attachments/assets/b494ac8b-0249-43f1-a1dc-9e26724968bf)

분리 결과 최초 API 요청 시에는 조회와 증가 SQL을 확인할 수 있으며
그 이후에는 조회 수 증가 SQL만 확인할 수 있습니다. 


## 체크 목록
- [X] 포스트맨으로 체크해 보았나요?