### PR TITLE
feat: add regist notification and read notification

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
@@ -8,6 +8,8 @@ import com.twoclock.gitconnect.domain.chat.repository.ChatMessageRepository;
 import com.twoclock.gitconnect.domain.chat.repository.ChatRoomRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.domain.notification.entity.constants.NotificationType;
+import com.twoclock.gitconnect.domain.notification.service.NotificationService;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
     private final MemberRepository memberRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public ChatMessageSaveRespDto sendMessage(String gitHubId, String chatRoomId, ChatMessageSaveReqDto chatMessageSaveReqDto) {
@@ -36,6 +39,7 @@ public class ChatMessageService {
                 .createdDateTime(LocalDateTime.now())
                 .build();
         chatMessageRepository.save(chatMessage);
+        notificationService.addNotificationInfo(member, NotificationType.CHAT);
 
         return new ChatMessageSaveRespDto(
                 chatMessage.getSenderMember().getLogin(),

--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
@@ -39,7 +39,9 @@ public class ChatMessageService {
                 .createdDateTime(LocalDateTime.now())
                 .build();
         chatMessageRepository.save(chatMessage);
-        notificationService.addNotificationInfo(member, NotificationType.CHAT);
+        if(!chatMessage.getSenderMember().equals(member)) {
+            notificationService.addNotificationInfo(member, NotificationType.CHAT);
+        }
 
         return new ChatMessageSaveRespDto(
                 chatMessage.getSenderMember().getLogin(),

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -49,7 +49,10 @@ public class CommentService {
                 .content(dto.content())
                 .build();
         commentRepository.save(comment);
-        notificationService.addNotificationInfo(member, NotificationType.COMMENT);
+
+        if (!board.getMember().equals(member)) {
+            notificationService.addNotificationInfo(member, NotificationType.COMMENT);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -9,6 +9,7 @@ import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.domain.notification.entity.constants.NotificationType;
 import com.twoclock.gitconnect.domain.notification.service.NotificationService;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
@@ -48,7 +49,7 @@ public class CommentService {
                 .content(dto.content())
                 .build();
         commentRepository.save(comment);
-        notificationService.addCommentNotification(member);
+        notificationService.addNotificationInfo(member, NotificationType.COMMENT);
     }
 
     @Transactional

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -9,6 +9,7 @@ import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.domain.notification.service.NotificationService;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import com.twoclock.gitconnect.global.model.Pagination;
@@ -32,6 +33,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
     private final BoardRepository boardRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public void saveComment(CommentRegistReqDto dto, String githubId, Long boardId) {
@@ -46,6 +48,7 @@ public class CommentService {
                 .content(dto.content())
                 .build();
         commentRepository.save(comment);
+        notificationService.addCommentNotification(member);
     }
 
     @Transactional

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -7,6 +7,8 @@ import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.like.repository.LikeRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.domain.notification.entity.constants.NotificationType;
+import com.twoclock.gitconnect.domain.notification.service.NotificationService;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import com.twoclock.gitconnect.global.model.Pagination;
@@ -29,6 +31,7 @@ public class LikeService {
     private final LikeRepository likeRepository;
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public void addLikeToBoard(Long boardId, String githubId) {
@@ -44,6 +47,7 @@ public class LikeService {
                 .member(member)
                 .build();
         likeRepository.save(likes);
+        notificationService.addNotificationInfo(member, NotificationType.LIKES);
     }
 
     @Transactional

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -47,7 +47,10 @@ public class LikeService {
                 .member(member)
                 .build();
         likeRepository.save(likes);
-        notificationService.addNotificationInfo(member, NotificationType.LIKES);
+
+        if(!board.getMember().equals(member)) {
+            notificationService.addNotificationInfo(member, NotificationType.LIKES);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/dto/NotificationRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/dto/NotificationRespDto.java
@@ -7,13 +7,15 @@ import java.time.LocalDateTime;
 public record NotificationRespDto(
         Long id,
         String message,
-        LocalDateTime createdDateTime
+        LocalDateTime createdDateTime,
+        boolean isRead
 ) {
     public NotificationRespDto(Notification notification) {
         this(
                 notification.getId(),
                 notification.getMessage(),
-                notification.getCreatedDateTime()
+                notification.getCreatedDateTime(),
+                notification.isRead()
         );
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
@@ -28,12 +28,22 @@ public class Notification extends BaseEntity {
 
     private String message;
 
-    private final boolean isRead = false;
+    private boolean isRead = false;
+
+    private boolean isSent = false;
 
     @Builder
     public Notification(Member member, NotificationType type, String message) {
         this.member = member;
         this.type = type;
         this.message = message;
+    }
+
+    public void setSent(boolean isSent) {
+        this.isSent = isSent;
+    }
+
+    public void setRead(boolean isRead) {
+        this.isRead = isRead;
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/entity/constants/NotificationType.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/entity/constants/NotificationType.java
@@ -6,9 +6,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum NotificationType {
-    COMMENT("댓글"),
-    LIKES("좋아요"),
-    CHAT("채팅");
+    COMMENT("댓글", "님이 댓글을 남겼습니다."),
+    LIKES("좋아요", "님이 좋아요를 눌렀습니다."),
+    CHAT("채팅", "님이 채팅을 보냈습니다.");
 
     private final String description;
+    private final String message;
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/repository/NotificationRepository.java
@@ -7,5 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    List<Notification> findByMemberAndIsSentFalse(Member member);
+    List<Notification> findByMemberAndIsSentFalseOrderByCreatedDateTimeDesc(Member member);
+
+    List<Notification> findByMemberOrderByCreatedDateTimeDesc(Member member);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/repository/NotificationRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    List<Notification> findByMemberAndIsReadFalse(Member member);
+    List<Notification> findByMemberAndIsSentFalse(Member member);
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -27,12 +27,19 @@ public class NotificationService {
 
     private final Map<Member, List<DeferredResult<List<NotificationRespDto>>>> waitingUsers = new ConcurrentHashMap<>();
 
+    @Transactional(readOnly = true)
+    public List<NotificationRespDto> getNotificationInfo(String githubId) {
+        Member member = validateMember(githubId);
+        List<Notification> notifications = notificationRepository.findByMemberOrderByCreatedDateTimeDesc(member);
+        return toMapNotificationResp(notifications);
+    }
+
     @Transactional
     public DeferredResult<List<NotificationRespDto>> getNotificationList(String githubId) {
         DeferredResult<List<NotificationRespDto>> deferredResult = new DeferredResult<>(60000L);
 
         Member member = validateMember(githubId);
-        List<Notification> notifications = notificationRepository.findByMemberAndIsSentFalse(member);
+        List<Notification> notifications = notificationRepository.findByMemberAndIsSentFalseOrderByCreatedDateTimeDesc(member);
         System.out.println("알림 목록 조회: " + notifications.size());
 
         if (!notifications.isEmpty()) {
@@ -67,7 +74,7 @@ public class NotificationService {
     }
 
     private void notifyUser(Member member) {
-        List<Notification> notifications = notificationRepository.findByMemberAndIsSentFalse(member);
+        List<Notification> notifications = notificationRepository.findByMemberAndIsSentFalseOrderByCreatedDateTimeDesc(member);
         if (!notifications.isEmpty()) {
             System.out.println("알림 전송 후 알림 상태 변경");
             notifications.forEach(n -> n.setSent(true));

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -35,6 +35,14 @@ public class NotificationService {
     }
 
     @Transactional
+    public void readNotification(Long notificationId, String githubId) {
+        Member member = validateMember(githubId);
+        Notification notification = validateNotification(notificationId, member);
+        notification.setRead(true);
+        notificationRepository.save(notification);
+    }
+
+    @Transactional(readOnly = true)
     public DeferredResult<List<NotificationRespDto>> getNotificationList(String githubId) {
         DeferredResult<List<NotificationRespDto>> deferredResult = new DeferredResult<>(60000L);
 
@@ -100,6 +108,15 @@ public class NotificationService {
 
     private Member validateMember(String githubId) {
         return memberRepository.findByGitHubId(githubId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    private Notification validateNotification(Long notificationId, Member member) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_NOTIFICATION));
+        if (!notification.getMember().equals(member)) {
+            throw new CustomException(ErrorCode.NOT_MATCH_MEMBER);
+        }
+        return notification;
     }
 
     private List<NotificationRespDto> toMapNotificationResp(List<Notification> notifications) {

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.domain.notification.dto.NotificationRespDto;
 import com.twoclock.gitconnect.domain.notification.entity.Notification;
+import com.twoclock.gitconnect.domain.notification.entity.constants.NotificationType;
 import com.twoclock.gitconnect.domain.notification.repository.NotificationRepository;
 import com.twoclock.gitconnect.global.exception.CustomException;
 import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
@@ -25,42 +26,60 @@ public class NotificationService {
     private final MemberRepository memberRepository;
 
     private final Map<Member, List<DeferredResult<List<NotificationRespDto>>>> waitingUsers = new ConcurrentHashMap<>();
-    private final Long NOTIFY_TIME_OUT = 60000L;
 
     @Transactional(readOnly = true)
     public DeferredResult<List<NotificationRespDto>> getNotificationList(String githubId) {
-        DeferredResult<List<NotificationRespDto>> deferredResult = new DeferredResult<>(NOTIFY_TIME_OUT);
+        DeferredResult<List<NotificationRespDto>> deferredResult = new DeferredResult<>(60000L);
 
         Member member = validateMember(githubId);
         List<Notification> notifications = notificationRepository.findByMemberAndIsReadFalse(member);
         if (!notifications.isEmpty()) {
-            // 새로운 알림이 있으면 바로 응답
+            System.out.println("새로운 알림이 있으면 바로 응답");
             deferredResult.setResult(toMapNotificationResp(notifications));
         } else {
-            // 새로운 알림이 없으면 대기 목록에 추가
+            System.out.println("새로운 알림이 없으면 대기 목록에 추가");
             waitingUsers.computeIfAbsent(member, k -> new ArrayList<>()).add(deferredResult);
         }
 
         deferredResult.onTimeout(() -> {
-            // 빈 List 반환
+            System.out.println("타임 아웃으로 인한 빈 알람 반환");
             deferredResult.setResult(new ArrayList<>());
             removeWaitingUser(member, deferredResult);
         });
 
-        // 요청이 완료되면 대기 목록에서 제거
+        System.out.println("요청이 완료되면 대기 목록에서 제거");
         deferredResult.onCompletion(() -> removeWaitingUser(member, deferredResult));
 
         return deferredResult;
     }
 
-    // TODO : 댓글, 게시글, 사용자 신고 알림 생성
     @Transactional
-    public void notifyUser(Member member) {
+    public void addCommentNotification(Member member) {
+        Notification notification = Notification.builder()
+                .member(member)
+                .type(NotificationType.COMMENT)
+                .message(member.getLogin() + NotificationType.COMMENT.getMessage())
+                .build();
+        notificationRepository.save(notification);
+        notifyUser(member);
+    }
+
+    private void notifyUser(Member member) {
         List<Notification> notifications = notificationRepository.findByMemberAndIsReadFalse(member);
-        List<DeferredResult<List<NotificationRespDto>>> userDeferredResults = waitingUsers.remove(member);
+        List<DeferredResult<List<NotificationRespDto>>> userDeferredResults = getAllDeferredResults();
         if (!userDeferredResults.isEmpty()) {
-            userDeferredResults.forEach(r -> r.setResult(toMapNotificationResp(notifications)));
+            userDeferredResults.forEach(r -> {
+                r.setResult(toMapNotificationResp(notifications));
+            });
         }
+    }
+
+    private List<DeferredResult<List<NotificationRespDto>>> getAllDeferredResults() {
+        List<DeferredResult<List<NotificationRespDto>>> allDeferredResults = new ArrayList<>();
+        for (List<DeferredResult<List<NotificationRespDto>>> deferredResults : waitingUsers.values()) {
+            allDeferredResults.addAll(deferredResults);
+        }
+        return allDeferredResults;
     }
 
     private Member validateMember(String githubId) {
@@ -74,9 +93,11 @@ public class NotificationService {
     private void removeWaitingUser(Member member, DeferredResult<List<NotificationRespDto>> deferredResult) {
         List<DeferredResult<List<NotificationRespDto>>> results = waitingUsers.get(member);
         if (results != null) {
+            System.out.println("대기 목록에서 제거 시도: " + member.getLogin());
             results.remove(deferredResult);
             if (results.isEmpty()) {
                 waitingUsers.remove(member);
+                System.out.println("대기 목록에서 사용자 제거됨: " + member.getLogin());
             }
         }
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -56,11 +56,11 @@ public class NotificationService {
     }
 
     @Transactional
-    public void addCommentNotification(Member member) {
+    public void addNotificationInfo(Member member, NotificationType type) {
         Notification notification = Notification.builder()
                 .member(member)
-                .type(NotificationType.COMMENT)
-                .message(member.getLogin() + NotificationType.COMMENT.getMessage())
+                .type(type)
+                .message(member.getLogin() + type.getMessage())
                 .build();
         notificationRepository.save(notification);
         notifyUser(member);

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
@@ -22,9 +22,8 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping
-    public RestResponse getNotificationList(@AuthenticationPrincipal UserDetails userDetails) {
+    public DeferredResult<List<NotificationRespDto>> getNotificationList(@AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails.getUsername();
-        DeferredResult<List<NotificationRespDto>> result = notificationService.getNotificationList(githubId);
-        return new RestResponse(result);
+        return notificationService.getNotificationList(githubId);
     }
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
@@ -6,10 +6,7 @@ import com.twoclock.gitconnect.global.model.RestResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
 
 import java.util.List;
@@ -25,6 +22,14 @@ public class NotificationController {
         String githubId = userDetails.getUsername();
         List<NotificationRespDto> result = notificationService.getNotificationInfo(githubId);
         return new RestResponse(result);
+    }
+
+    @PutMapping("{notificationId}")
+    public RestResponse readNotification(@PathVariable Long notificationId,
+                                         @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        notificationService.readNotification(notificationId, githubId);
+        return RestResponse.OK();
     }
 
     @GetMapping

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
@@ -20,6 +20,12 @@ import java.util.List;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    @GetMapping("/list")
+    public RestResponse getNotificationInfo(@AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        List<NotificationRespDto> result = notificationService.getNotificationInfo(githubId);
+        return new RestResponse(result);
+    }
 
     @GetMapping
     public DeferredResult<List<NotificationRespDto>> getNotificationList(@AuthenticationPrincipal UserDetails userDetails) {

--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
@@ -33,7 +33,8 @@ public class WebSecurityConfig {
             "/api/v1/boards",
             "/api/v1/boards/*",
             "/api/v1/boards/*/comments",
-            "/api/v1/likes/*"
+            "/api/v1/likes/*",
+            "/api/v1/notification",
     };
     private static final String[] POST_PERMIT_STRINGS = {
             "/api/v1/members/auth/logout",

--- a/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
+++ b/src/main/java/com/twoclock/gitconnect/global/exception/constants/ErrorCode.java
@@ -23,6 +23,9 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "M-001", "찾을 수 없는 회원 계정입니다."),
     DIFF_USER_BOARD(HttpStatus.FORBIDDEN, "M-002", "게시글을 등록한 사용자와 일치하지 않습니다."),
 
+    NOT_FOUND_NOTIFICATION(HttpStatus.NOT_FOUND, "N-001", "찾을 수 없는 알림입니다."),
+    NOT_MATCH_MEMBER(HttpStatus.FORBIDDEN, "N-002", "알림을 읽을 수 있는 권한이 없습니다."),
+
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "C-001", "찾을 수 없는 카테고리입니다."),
 
     OPEN_API_SERVER_ERROR(HttpStatus.BAD_REQUEST, "G-001", "Open API 서버 에러가 발생했습니다."),


### PR DESCRIPTION
## 관련 이슈

* #93 

## 변경 사항
> **알림 발송 API**
API : `/api/v1/notification` [GET]

* #97 에서 이미 추가한 기능이지만 수정사항 존재
(이전에는 알림이 존재하던 존재하지 않던 결과를 바로 반환)

해당 API를 실행하면 반환할 알림이 존재하지 않으면 60초동안 결과 반환이 지연됩니다.
  - 60초 Timeout 이후에는 빈 배열 반환처리 됨
![image](https://github.com/user-attachments/assets/f3bd6db7-db18-46f5-9209-a884936bac3d)

알람 API가 지연되는 도중 새로운 알람이 생기는 경우에는 바로 응답을 합니다.
- ex) 자신의 게시글에 새로운 댓글이 생기는 경우
![image](https://github.com/user-attachments/assets/9596b602-9157-4a1a-8042-bb6687df2eb7)

---
> **알림 목록 확인 API**
API : `/api/v1/notification/list` [GET]

알림 발송일 기준으로 내림차순 처리

**Response**
```
{
    "message": "OK",
    "data": [
        {
            "id": 7,
            "message": "jjangsky님이 댓글을 남겼습니다.",
            "createdDateTime": "2024-09-18T23:04:40.959413",
            "isRead": false
        },
        {
            "id": 6,
            "message": "jjangsky님이 댓글을 남겼습니다.",
            "createdDateTime": "2024-09-18T23:02:45.177312",
            "isRead": false
        }
    ]
}
```

> **알림 읽기 API**
API : `api/v1/notification` [PUT]

해당 API를 사용하면 `isRead` 컬럼 값을 true로 반환할 수 있습니다.
- `isRead`: 사용자가 알람을 확인하였는지에 대한 구분 컬럼
- `isSent`: 서버에서 사용자에게 알람을 발송하였는지에 대한 구분 컬럼


LongPolling 방식으로 알람을 처리하다 보니 사용자 측에서 `알람 발송 API` 를 계속 실행해야 하는 구조입니다.
- Timeout으로 인한 빈 배열 반환 -> 다시 실행
- 정상적으로 알람 도착 -> 다시 실행 -> 새로운 알람이 올 때 까지 60초 주기로 Timeout 발생

``` javascript
function fetchNotifications() {
    fetch('/notifications')
        .then(response => response.json())
        .then(data => {
            if (data.length > 0) {
                // 새로운 알림이 있을 경우 화면에 표시
                displayNotifications(data);
            }
            // 즉시 새로운 Long Polling 요청을 보냄
            fetchNotifications();
        })
        .catch(() => {
            // 오류 발생 시 일정 시간 대기 후 다시 요청
            setTimeout(fetchNotifications, 5000);
        });
}

// 페이지 로드 시 알림 요청 시작
fetchNotifications();
```

---
> **알림 처리 로직 도식화**
``` mermaid
sequenceDiagram
    participant Client as 클라이언트
    participant Server as 서버
    participant EventSource as 알림

    Client->>Server: Long Polling 요청
    activate Server
    Server-->>Client: 연결 유지 (타임아웃까지)
    deactivate Server
    
    loop 알림 발생 대기
        EventSource->>Server: 알림 발생
        alt 알림 있음
            Server->>Client: 응답 (알림 데이터)
            Client->>Server: 새 Long Polling 요청
        else 타임아웃
            Server->>Client: 빈 응답 또는 타임아웃 응답
            Client->>Server: 새 Long Polling 요청
        end
    end
```


> 추가적으로 원래는 자신의 게시글에 댓글이나 좋아요를 누르면 알람이 가지 않는 것이 정상이지만
원활한 테스트를 위해 자신의 게시글의 댓글 및 좋아요를 눌러도 알람처리가 가도록 설정하였습니다.
@openmpy 님 확인 후 추가로 로직 작성하여 merge 처리 하겠습니다.

## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?