### PR TITLE
feat: Implement weekly popular members and repositories based on likes

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikePopularWeekMemberRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikePopularWeekMemberRespDto.java
@@ -1,0 +1,10 @@
+package com.twoclock.gitconnect.domain.like.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record LikePopularWeekMemberRespDto(String login, String avatarUrl) {
+
+    @QueryProjection
+    public LikePopularWeekMemberRespDto {
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikePopularWeekRepositoryRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikePopularWeekRepositoryRespDto.java
@@ -1,0 +1,15 @@
+package com.twoclock.gitconnect.domain.like.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record LikePopularWeekRepositoryRespDto(
+        String title,
+        String content,
+        String login,
+        Long likeCount
+) {
+
+    @QueryProjection
+    public LikePopularWeekRepositoryRespDto {
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikePopularWeekRepositoryRespDto.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/dto/LikePopularWeekRepositoryRespDto.java
@@ -3,6 +3,7 @@ package com.twoclock.gitconnect.domain.like.dto;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record LikePopularWeekRepositoryRespDto(
+        Long boardId,
         String title,
         String content,
         String login,

--- a/src/main/java/com/twoclock/gitconnect/domain/like/entity/Likes.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/entity/Likes.java
@@ -7,14 +7,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 public class Likes {
 
     @Id

--- a/src/main/java/com/twoclock/gitconnect/domain/like/entity/Likes.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/entity/Likes.java
@@ -35,9 +35,9 @@ public class Likes {
     private LocalDateTime createdDateTime;
 
     @Builder
-    public Likes(Board board, Member member) {
+    public Likes(Board board, Member member, LocalDateTime createdDateTime) {
         this.board = board;
         this.member = member;
+        this.createdDateTime = createdDateTime;
     }
-
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/entity/Likes.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/entity/Likes.java
@@ -7,7 +7,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -30,7 +29,6 @@ public class Likes {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdDateTime;
 

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/CustomLikeRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/CustomLikeRepository.java
@@ -1,6 +1,7 @@
 package com.twoclock.gitconnect.domain.like.repository;
 
 import com.twoclock.gitconnect.domain.like.dto.LikePopularWeekMemberRespDto;
+import com.twoclock.gitconnect.domain.like.dto.LikePopularWeekRepositoryRespDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -8,6 +9,10 @@ import java.util.List;
 public interface CustomLikeRepository {
 
     List<LikePopularWeekMemberRespDto> findTopMemberByLikesBetween(
+            LocalDateTime startDateTime, LocalDateTime endDateTime, int limit
+    );
+
+    List<LikePopularWeekRepositoryRespDto> findTopRepositoryByLikesBetween(
             LocalDateTime startDateTime, LocalDateTime endDateTime, int limit
     );
 }

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/CustomLikeRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/CustomLikeRepository.java
@@ -1,0 +1,13 @@
+package com.twoclock.gitconnect.domain.like.repository;
+
+import com.twoclock.gitconnect.domain.like.dto.LikePopularWeekMemberRespDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CustomLikeRepository {
+
+    List<LikePopularWeekMemberRespDto> findTopMemberByLikesBetween(
+            LocalDateTime startDateTime, LocalDateTime endDateTime, int limit
+    );
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepository.java
@@ -9,8 +9,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface LikeRepository extends JpaRepository<Likes, Long> {
+public interface LikeRepository extends JpaRepository<Likes, Long>, CustomLikeRepository {
+
     boolean existsByBoardAndMember(Board board, Member member);
+
     Optional<Likes> findByBoardAndMember(Board board, Member member);
 
     Page<Likes> findAllByBoard(Board board, Pageable pageable);

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepositoryImpl.java
@@ -45,7 +45,9 @@ public class LikeRepositoryImpl implements CustomLikeRepository {
             LocalDateTime startDateTime, LocalDateTime endDateTime, int limit
     ) {
         return queryFactory.select(
-                        new QLikePopularWeekRepositoryRespDto(board.title, board.content, member.login, likes.count())
+                        new QLikePopularWeekRepositoryRespDto(
+                                board.id, board.title, board.content, member.login, likes.count()
+                        )
                 )
                 .from(likes)
                 .join(likes.board, board)
@@ -53,7 +55,7 @@ public class LikeRepositoryImpl implements CustomLikeRepository {
                 .where(likes.createdDateTime.between(startDateTime, endDateTime)
                         .and(board.category.eq(Category.BD2))
                 )
-                .groupBy(board.title, board.content, member.login)
+                .groupBy(board.id, board.title, board.content, member.login)
                 .orderBy(likes.count().desc())
                 .limit(limit)
                 .fetch();

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepositoryImpl.java
@@ -3,7 +3,9 @@ package com.twoclock.gitconnect.domain.like.repository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.like.dto.LikePopularWeekMemberRespDto;
+import com.twoclock.gitconnect.domain.like.dto.LikePopularWeekRepositoryRespDto;
 import com.twoclock.gitconnect.domain.like.dto.QLikePopularWeekMemberRespDto;
+import com.twoclock.gitconnect.domain.like.dto.QLikePopularWeekRepositoryRespDto;
 import jakarta.persistence.EntityManager;
 
 import java.time.LocalDateTime;
@@ -33,6 +35,25 @@ public class LikeRepositoryImpl implements CustomLikeRepository {
                         .and(board.category.eq(Category.BD1))
                 )
                 .groupBy(member.id)
+                .orderBy(likes.count().desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<LikePopularWeekRepositoryRespDto> findTopRepositoryByLikesBetween(
+            LocalDateTime startDateTime, LocalDateTime endDateTime, int limit
+    ) {
+        return queryFactory.select(
+                        new QLikePopularWeekRepositoryRespDto(board.title, board.content, member.login, likes.count())
+                )
+                .from(likes)
+                .join(likes.board, board)
+                .join(board.member, member)
+                .where(likes.createdDateTime.between(startDateTime, endDateTime)
+                        .and(board.category.eq(Category.BD2))
+                )
+                .groupBy(board.title, board.content, member.login)
                 .orderBy(likes.count().desc())
                 .limit(limit)
                 .fetch();

--- a/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/repository/LikeRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.twoclock.gitconnect.domain.like.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twoclock.gitconnect.domain.board.entity.constants.Category;
+import com.twoclock.gitconnect.domain.like.dto.LikePopularWeekMemberRespDto;
+import com.twoclock.gitconnect.domain.like.dto.QLikePopularWeekMemberRespDto;
+import jakarta.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.twoclock.gitconnect.domain.board.entity.QBoard.board;
+import static com.twoclock.gitconnect.domain.like.entity.QLikes.likes;
+import static com.twoclock.gitconnect.domain.member.entity.QMember.member;
+
+public class LikeRepositoryImpl implements CustomLikeRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public LikeRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<LikePopularWeekMemberRespDto> findTopMemberByLikesBetween(
+            LocalDateTime startDateTime, LocalDateTime endDateTime, int limit
+    ) {
+        return queryFactory.select(new QLikePopularWeekMemberRespDto(member.login, member.avatarUrl))
+                .from(likes)
+                .join(likes.board, board)
+                .join(board.member, member)
+                .where(likes.createdDateTime.between(startDateTime, endDateTime)
+                        .and(board.category.eq(Category.BD1))
+                )
+                .groupBy(member.id)
+                .orderBy(likes.count().desc())
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -38,6 +38,7 @@ public class LikeService {
     public void addLikeToBoard(Long boardId, String githubId) {
         Board board = validateBoard(boardId);
         Member member = validateMember(githubId);
+
         boolean duplicated = likeRepository.existsByBoardAndMember(board, member);
         if (duplicated) {
             throw new CustomException(ErrorCode.DUPLICATED_LIKE);
@@ -46,7 +47,9 @@ public class LikeService {
         Likes likes = Likes.builder()
                 .board(board)
                 .member(member)
+                .createdDateTime(LocalDateTime.now())
                 .build();
+
         likeRepository.save(likes);
     }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -2,6 +2,7 @@ package com.twoclock.gitconnect.domain.like.service;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
+import com.twoclock.gitconnect.domain.like.dto.LikePopularWeekMemberRespDto;
 import com.twoclock.gitconnect.domain.like.dto.LikesRespDto;
 import com.twoclock.gitconnect.domain.like.entity.Likes;
 import com.twoclock.gitconnect.domain.like.repository.LikeRepository;
@@ -20,6 +21,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -82,6 +86,21 @@ public class LikeService {
         Member member = validateMember(gitHubId);
 
         return likeRepository.existsByBoardAndMember(board, member);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LikePopularWeekMemberRespDto> getPopularWeekMember() {
+        LocalDate now = LocalDate.now();
+
+        LocalDate startOfWeek = now.with(DayOfWeek.MONDAY);
+        LocalDate endOfWeek = now.with(DayOfWeek.SUNDAY);
+
+        LocalDateTime startOfWeekDateTime = startOfWeek.atStartOfDay();
+        LocalDateTime endOfWeekDateTime = endOfWeek.atTime(23, 59, 59);
+
+        int limit = 5;
+
+        return likeRepository.findTopMemberByLikesBetween(startOfWeekDateTime, endOfWeekDateTime, limit);
     }
 
     private Board validateBoard(Long boardId) {

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -106,6 +106,21 @@ public class LikeService {
         return likeRepository.findTopMemberByLikesBetween(startOfWeekDateTime, endOfWeekDateTime, limit);
     }
 
+    @Transactional(readOnly = true)
+    public Object getPopularWeekRepository() {
+        LocalDate now = LocalDate.now();
+
+        LocalDate startOfWeek = now.with(DayOfWeek.MONDAY);
+        LocalDate endOfWeek = now.with(DayOfWeek.SUNDAY);
+
+        LocalDateTime startOfWeekDateTime = startOfWeek.atStartOfDay();
+        LocalDateTime endOfWeekDateTime = endOfWeek.atTime(23, 59, 59);
+
+        int limit = 10;
+
+        return likeRepository.findTopRepositoryByLikesBetween(startOfWeekDateTime, endOfWeekDateTime, limit);
+    }
+
     private Board validateBoard(Long boardId) {
         return boardRepository.findById(boardId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_BOARD)

--- a/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
@@ -44,6 +44,11 @@ public class LikeController {
         return new RestResponse(likeService.getPopularWeekMember());
     }
 
+    @GetMapping("/popular-week/repositories")
+    public RestResponse getPopularWeekRepository() {
+        return new RestResponse(likeService.getPopularWeekRepository());
+    }
+
 //    @GetMapping("/{boardId}")
 //    public RestResponse getLikesByBoardId(@PathVariable("boardId") Long boardId,
 //                                          @RequestParam(value = "page", defaultValue = "0") int page,

--- a/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/web/LikeController.java
@@ -39,6 +39,11 @@ public class LikeController {
         return new RestResponse(result);
     }
 
+    @GetMapping("/popular-week/members")
+    public RestResponse getPopularWeekMember() {
+        return new RestResponse(likeService.getPopularWeekMember());
+    }
+
 //    @GetMapping("/{boardId}")
 //    public RestResponse getLikesByBoardId(@PathVariable("boardId") Long boardId,
 //                                          @RequestParam(value = "page", defaultValue = "0") int page,

--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
@@ -33,7 +33,8 @@ public class WebSecurityConfig {
             "/api/v1/boards",
             "/api/v1/boards/*",
             "/api/v1/boards/*/comments",
-            "/api/v1/likes/*"
+            "/api/v1/likes/*",
+            "/api/v1/likes/popular-week/*",
     };
     private static final String[] POST_PERMIT_STRINGS = {
             "/api/v1/members/auth/logout",

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -5,6 +5,8 @@ import com.twoclock.gitconnect.domain.board.entity.constants.Category;
 import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
 import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
+import com.twoclock.gitconnect.domain.like.entity.Likes;
+import com.twoclock.gitconnect.domain.like.repository.LikeRepository;
 import com.twoclock.gitconnect.domain.member.entity.Member;
 import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.domain.notification.entity.Notification;
@@ -17,9 +19,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static com.twoclock.gitconnect.domain.member.entity.constants.Role.ROLE_USER;
 
@@ -33,7 +37,7 @@ public class DummyDevlnit {
     CommandLineRunner init(MemberRepository memberRepository,
                            BoardRepository boardRepository,
                            CommentRepository commentRepository,
-                           NotificationRepository notificationRepository) {
+                           NotificationRepository notificationRepository, LikeRepository likeRepository) {
         return (args) -> {
             log.info("Dummy Data Init");
             Faker faker = new Faker();
@@ -47,7 +51,8 @@ public class DummyDevlnit {
 
             // 테스트 게시글 생성
             List<Board> boards = new ArrayList<>();
-            createDummyBoards(boards, "계정 홍보 테스트 게시글", Category.BD1, 100, members.get(0));
+            createDummyBoards(boards, "계정 홍보 테스트 게시글", Category.BD1, 50, members.get(0));
+            createDummyBoards(boards, "계정 홍보 테스트 게시글2", Category.BD1, 50, members.get(1));
             createDummyBoards(boards, "저장소 홍보 테스트 게시글", Category.BD2, 100, members.get(0));
             createDummyBoards(boards, "사용자 신고 테스트 게시글", Category.BD3, 100, members.get(0));
             boardRepository.saveAll(boards);
@@ -56,6 +61,16 @@ public class DummyDevlnit {
             List<Comment> comments = new ArrayList<>();
             createDummyComments(comments, 5, members.get(0), boards.get(0));
             commentRepository.saveAll(comments);
+
+            // 테스트 좋아요 생성
+            List<Likes> likes = new ArrayList<>();
+
+            IntStream.range(0, 5)
+                    .forEach(i -> createDummyLike(likes, members.get(1), boards.get(i), LocalDateTime.now()));
+            IntStream.range(50, 60)
+                    .forEach(i -> createDummyLike(likes, members.get(0), boards.get(i), LocalDateTime.now()));
+
+            likeRepository.saveAll(likes);
 
             // 테스트 알림 생성
             List<Notification> notification = new ArrayList<>();
@@ -89,6 +104,16 @@ public class DummyDevlnit {
                     .build();
             comments.add(comment);
         }
+    }
+
+    private void createDummyLike(List<Likes> likes, Member member, Board board, LocalDateTime createDateTime) {
+        Likes like = Likes.builder()
+                .board(board)
+                .member(member)
+                .createdDateTime(createDateTime)
+                .build();
+
+        likes.add(like);
     }
 
     private void createDummyNotifications(List<Notification> notifications, int count,

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyDevlnit.java
@@ -45,7 +45,8 @@ public class DummyDevlnit {
             // 테스트 계정 생성
             List<Member> members = Arrays.asList(
                     new Member("loginId-1", "1234", faker.avatar().image(), "테스트 유저 1", ROLE_USER),
-                    new Member("loginId-2", "5678", faker.avatar().image(), "테스트 유저 2", ROLE_USER)
+                    new Member("loginId-2", "5678", faker.avatar().image(), "테스트 유저 2", ROLE_USER),
+                    new Member("loginId-3", "0000", faker.avatar().image(), "테스트 유저 3", ROLE_USER)
             );
             memberRepository.saveAll(members);
 
@@ -53,7 +54,8 @@ public class DummyDevlnit {
             List<Board> boards = new ArrayList<>();
             createDummyBoards(boards, "계정 홍보 테스트 게시글", Category.BD1, 50, members.get(0));
             createDummyBoards(boards, "계정 홍보 테스트 게시글2", Category.BD1, 50, members.get(1));
-            createDummyBoards(boards, "저장소 홍보 테스트 게시글", Category.BD2, 100, members.get(0));
+            createDummyBoards(boards, "저장소 홍보 테스트 게시글", Category.BD2, 50, members.get(0));
+            createDummyBoards(boards, "저장소 홍보 테스트 게시글2", Category.BD2, 50, members.get(1));
             createDummyBoards(boards, "사용자 신고 테스트 게시글", Category.BD3, 100, members.get(0));
             boardRepository.saveAll(boards);
 
@@ -69,6 +71,10 @@ public class DummyDevlnit {
                     .forEach(i -> createDummyLike(likes, members.get(1), boards.get(i), LocalDateTime.now()));
             IntStream.range(50, 60)
                     .forEach(i -> createDummyLike(likes, members.get(0), boards.get(i), LocalDateTime.now()));
+
+            createDummyLike(likes, members.get(0), boards.get(150), LocalDateTime.now());
+            createDummyLike(likes, members.get(1), boards.get(100), LocalDateTime.now());
+            createDummyLike(likes, members.get(2), boards.get(100), LocalDateTime.now());
 
             likeRepository.saveAll(likes);
 

--- a/src/test/java/com/twoclock/gitconnect/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/twoclock/gitconnect/domain/like/service/LikeServiceTest.java
@@ -1,0 +1,47 @@
+package com.twoclock.gitconnect.domain.like.service;
+
+import com.twoclock.gitconnect.domain.like.dto.LikePopularWeekMemberRespDto;
+import com.twoclock.gitconnect.domain.like.repository.LikeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @DisplayName("주간 인기 멤버 조회가 정상적으로 작동 하는지 확인")
+    @Test
+    void getPopularWeekMember_1() {
+        // given
+        LocalDateTime startDateTime = LocalDateTime.of(2024, 9, 16, 0, 0, 0);
+        LocalDateTime endDateTime = LocalDateTime.of(2024, 9, 22, 23, 59, 59);
+        int limit = 5;
+
+        // when
+        when(likeRepository.findTopMemberByLikesBetween(startDateTime, endDateTime, limit))
+                .thenReturn(List.of(
+                        new LikePopularWeekMemberRespDto("login-1", "avatar-1"),
+                        new LikePopularWeekMemberRespDto("login-2", "avatar-2")
+                ));
+
+        List<LikePopularWeekMemberRespDto> result = likeService.getPopularWeekMember();
+
+        // then
+        assertEquals(2, result.size());
+    }
+}


### PR DESCRIPTION
## 관련 이슈

* #114 

## 변경 사항

* 한 주 동안 인기 계정 및 저장소 기능을 구현 했습니다.
* 기능이 정상적으로 작동 하는지 안하는지 정도의 테스트 코드만 작성해둔 상태입니다.

<img width="542" alt="스크린샷 2024-09-19 오후 5 08 52" src="https://github.com/user-attachments/assets/8e26ebb2-9ded-4cb7-b428-6e0812bee8ef">

### 인기 계정 응답 값
> GET http://127.0.0.1:8082/api/v1/likes/popular-week/members
```json
{
  "message": "OK",
  "data": [
    {
      "login": "loginId-2",
      "avatarUrl": "https://robohash.org/ocptvnbq.png"
    },
    {
      "login": "loginId-1",
      "avatarUrl": "https://robohash.org/luwvmskq.png"
    }
  ]
}
```

### 인기 저장소 응답 값
> GET http://127.0.0.1:8082/api/v1/likes/popular-week/repositories
```json
{
  "message": "OK",
  "data": [
    {
      "boardId": 101,
      "title": "저장소 홍보 테스트 게시글0",
      "content": "테스트 게시글 내용0",
      "login": "loginId-1",
      "likeCount": 2
    },
    {
      "boardId": 151,
      "title": "저장소 홍보 테스트 게시글20",
      "content": "테스트 게시글 내용0",
      "login": "loginId-2",
      "likeCount": 1
    }
  ]
}
```

## 체크 목록

- [x] 포스트맨으로 체크해 보았나요?
- [x] 테스트 코드를 작성 하셨나요?