### PR TITLE
feat: add soft delete to notification 

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/chat/service/ChatMessageService.java
@@ -40,7 +40,7 @@ public class ChatMessageService {
                 .build();
       
         if(!chatMessage.getSenderMember().equals(member)) {
-            notificationService.addNotificationInfo(member, NotificationType.CHAT);
+            notificationService.addNotificationInfo(chatRoom.getReceivedMember(), NotificationType.CHAT, member.getLogin());
         }
       
         ChatMessage savedMessage = chatMessageRepository.save(chatMessage);

--- a/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/comment/service/CommentService.java
@@ -51,7 +51,7 @@ public class CommentService {
         commentRepository.save(comment);
 
         if (!board.getMember().equals(member)) {
-            notificationService.addNotificationInfo(member, NotificationType.COMMENT);
+            notificationService.addNotificationInfo(board.getMember(), NotificationType.COMMENT,  member.getLogin());
         }
     }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/like/service/LikeService.java
@@ -56,7 +56,7 @@ public class LikeService {
         likeRepository.save(likes);
 
         if(!board.getMember().equals(member)) {
-            notificationService.addNotificationInfo(member, NotificationType.LIKES);
+            notificationService.addNotificationInfo(board.getMember(), NotificationType.LIKES,  member.getLogin());
         }
     }
 

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
@@ -8,10 +8,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE notification SET is_delete = true WHERE id = ?")
+@Where(clause = "is_delete = false")
 public class Notification extends BaseEntity {
 
     @Id
@@ -28,9 +32,14 @@ public class Notification extends BaseEntity {
 
     private String message;
 
+    @Column(nullable = false)
     private boolean isRead = false;
 
+    @Column(nullable = false)
     private boolean isSent = false;
+
+    @Column(nullable = false)
+    private final boolean isDelete = false;
 
     @Builder
     public Notification(Member member, NotificationType type, String message) {

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/entity/Notification.java
@@ -32,13 +32,10 @@ public class Notification extends BaseEntity {
 
     private String message;
 
-    @Column(nullable = false)
     private boolean isRead = false;
 
-    @Column(nullable = false)
     private boolean isSent = false;
 
-    @Column(nullable = false)
     private final boolean isDelete = false;
 
     @Builder

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -42,6 +42,13 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
+    @Transactional
+    public void deleteNotification(Long notificationId, String githubId) {
+        Member member = validateMember(githubId);
+        Notification notification = validateNotification(notificationId, member);
+        notificationRepository.delete(notification);
+    }
+
     @Transactional(readOnly = true)
     public DeferredResult<List<NotificationRespDto>> getNotificationList(String githubId) {
         DeferredResult<List<NotificationRespDto>> deferredResult = new DeferredResult<>(60000L);

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -73,11 +73,11 @@ public class NotificationService {
     }
 
     @Transactional
-    public void addNotificationInfo(Member member, NotificationType type) {
+    public void addNotificationInfo(Member member, NotificationType type, String userId) {
         Notification notification = Notification.builder()
                 .member(member)
                 .type(type)
-                .message(member.getLogin() + type.getMessage())
+                .message(userId + type.getMessage())
                 .build();
         notificationRepository.save(notification);
         notifyUser(member);

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/service/NotificationService.java
@@ -55,23 +55,18 @@ public class NotificationService {
 
         Member member = validateMember(githubId);
         List<Notification> notifications = notificationRepository.findByMemberAndIsSentFalseOrderByCreatedDateTimeDesc(member);
-        System.out.println("알림 목록 조회: " + notifications.size());
 
         if (!notifications.isEmpty()) {
-            System.out.println("새로운 알림이 있으면 바로 응답");
             deferredResult.setResult(toMapNotificationResp(notifications));
         } else {
-            System.out.println("새로운 알림이 없으면 대기 목록에 추가");
             waitingUsers.computeIfAbsent(member, k -> new ArrayList<>()).add(deferredResult);
         }
 
         deferredResult.onTimeout(() -> {
-            System.out.println("타임 아웃으로 인한 빈 알람 반환");
             deferredResult.setResult(new ArrayList<>());
             removeWaitingUser(member, deferredResult);
         });
 
-        System.out.println("요청이 완료되면 대기 목록에서 제거");
         deferredResult.onCompletion(() -> removeWaitingUser(member, deferredResult));
 
         return deferredResult;
@@ -91,7 +86,6 @@ public class NotificationService {
     private void notifyUser(Member member) {
         List<Notification> notifications = notificationRepository.findByMemberAndIsSentFalseOrderByCreatedDateTimeDesc(member);
         if (!notifications.isEmpty()) {
-            System.out.println("알림 전송 후 알림 상태 변경");
             notifications.forEach(n -> n.setSent(true));
             notificationRepository.saveAll(notifications);
         }
@@ -99,7 +93,6 @@ public class NotificationService {
         List<DeferredResult<List<NotificationRespDto>>> userDeferredResults = getAllDeferredResults();
         if (!userDeferredResults.isEmpty()) {
             userDeferredResults.forEach(r -> {
-                System.out.println("대기중인 알림 객체에게 알림 전송");
                 r.setResult(toMapNotificationResp(notifications));
             });
         }
@@ -133,11 +126,9 @@ public class NotificationService {
     private void removeWaitingUser(Member member, DeferredResult<List<NotificationRespDto>> deferredResult) {
         List<DeferredResult<List<NotificationRespDto>>> results = waitingUsers.get(member);
         if (results != null) {
-            System.out.println("대기 목록에서 제거 시도: " + member.getLogin());
             results.remove(deferredResult);
             if (results.isEmpty()) {
                 waitingUsers.remove(member);
-                System.out.println("대기 목록에서 사용자 제거됨: " + member.getLogin());
             }
         }
     }

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
@@ -32,6 +32,14 @@ public class NotificationController {
         return RestResponse.OK();
     }
 
+    @DeleteMapping("{notificationId}")
+    public RestResponse deleteNotification(@PathVariable Long notificationId,
+                                           @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        notificationService.deleteNotification(notificationId, githubId);
+        return RestResponse.OK();
+    }
+
     @GetMapping
     public DeferredResult<List<NotificationRespDto>> getNotificationList(@AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails.getUsername();

--- a/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
+++ b/src/main/java/com/twoclock/gitconnect/domain/notification/web/NotificationController.java
@@ -24,7 +24,7 @@ public class NotificationController {
         return new RestResponse(result);
     }
 
-    @PutMapping("{notificationId}")
+    @PutMapping("/{notificationId}")
     public RestResponse readNotification(@PathVariable Long notificationId,
                                          @AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails.getUsername();
@@ -32,7 +32,7 @@ public class NotificationController {
         return RestResponse.OK();
     }
 
-    @DeleteMapping("{notificationId}")
+    @DeleteMapping("/{notificationId}")
     public RestResponse deleteNotification(@PathVariable Long notificationId,
                                            @AuthenticationPrincipal UserDetails userDetails) {
         String githubId = userDetails.getUsername();


### PR DESCRIPTION
## 관련 이슈

* #118 

## 변경 사항

> 알림 삭제 기능 구현

`API : /api/v1/notification/{notificationId}`
- soft delete로 구현

![image](https://github.com/user-attachments/assets/2c4f86ca-0eb6-49a0-b45e-ff1d995528a1)



> 추가적으로 기존 알림 저장 시 Notification Entity 에서 DB에 알림 보내는 사람을 저장하였습니다
> 이 부분 알림을 받는 사용자로 수정하였습니다.


## 체크 목록

- [X] 포스트맨으로 체크해 보았나요?
