### PR TITLE
test: add Comment entity Business layer test code

### DIFF
--- a/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/twoclock/gitconnect/global/config/WebSecurityConfig.java
@@ -60,7 +60,8 @@ public class WebSecurityConfig {
                         "http://localhost:3000", "http://127.0.0.1:3000",
                         "http://localhost:5500", "http://127.0.0.1:5500",
                         "http://localhost:7777", "http://127.0.0.1:7777",
-                        "https://www.git-connect.site"
+                        "https://www.git-connect.site",
+                        "https://git-connect.site"
                 )
         );
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyObject.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyObject.java
@@ -2,12 +2,19 @@ package com.twoclock.gitconnect.global.dummy;
 
 import com.twoclock.gitconnect.domain.board.entity.Board;
 import com.twoclock.gitconnect.domain.board.entity.constants.Category;
+import com.twoclock.gitconnect.domain.comment.dto.CommentRegistReqDto;
+import com.twoclock.gitconnect.domain.comment.entity.Comment;
 import com.twoclock.gitconnect.domain.member.entity.Member;
-import net.datafaker.Faker;
 
 import static com.twoclock.gitconnect.domain.member.entity.constants.Role.ROLE_USER;
 
 public class DummyObject {
+
+    /**
+     * Test Code 작성 시 Dummy Data 생성을 위한 Class
+     * method 앞에 `mock`이 붙으면 가짜 객체 생성
+     * method 앞에 `new`가 붙으면 실제 객체 생성
+     */
 
     protected Member mockMember(String gitHubId) {
         return new Member(
@@ -28,4 +35,5 @@ public class DummyObject {
                 "테스트 게시글 내용"
         );
     }
+
 }

--- a/src/main/java/com/twoclock/gitconnect/global/dummy/DummyObject.java
+++ b/src/main/java/com/twoclock/gitconnect/global/dummy/DummyObject.java
@@ -1,0 +1,31 @@
+package com.twoclock.gitconnect.global.dummy;
+
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.board.entity.constants.Category;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import net.datafaker.Faker;
+
+import static com.twoclock.gitconnect.domain.member.entity.constants.Role.ROLE_USER;
+
+public class DummyObject {
+
+    protected Member mockMember(String gitHubId) {
+        return new Member(
+                "mockUser",
+                gitHubId,
+                "testUrl",
+                "유저1",
+                ROLE_USER
+        );
+    }
+
+    protected Board mockBoard(Member member) {
+        return new Board(
+                member,
+                member.getName(),
+                Category.BD1,
+                "테스트 게시글",
+                "테스트 게시글 내용"
+        );
+    }
+}

--- a/src/test/java/com/twoclock/gitconnect/config/IntegrationTestSupport.java
+++ b/src/test/java/com/twoclock/gitconnect/config/IntegrationTestSupport.java
@@ -1,0 +1,13 @@
+package com.twoclock.gitconnect.config;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("local")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class IntegrationTestSupport {
+}

--- a/src/test/java/com/twoclock/gitconnect/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/twoclock/gitconnect/domain/comment/service/CommentServiceTest.java
@@ -11,6 +11,7 @@ import com.twoclock.gitconnect.domain.notification.entity.constants.Notification
 import com.twoclock.gitconnect.domain.notification.service.NotificationService;
 import com.twoclock.gitconnect.global.dummy.DummyObject;
 import com.twoclock.gitconnect.global.exception.CustomException;
+import com.twoclock.gitconnect.global.exception.constants.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -68,7 +69,7 @@ class CommentServiceTest extends DummyObject {
         @DisplayName("댓글을 입력할 경우 정상적으로 등록되어야 한다.")
         @Test
         void saveComment() {
-            // given
+            // given & stub
             BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.ofNullable(member));
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
 
@@ -82,7 +83,7 @@ class CommentServiceTest extends DummyObject {
         @DisplayName("댓글을 입력할 경우 작성자와 게시글 작성자가 동일한 경우 알람이 발송되지 않아야 한다.")
         @Test
         void notSentNotify() {
-            // given
+            // given & stub
             BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.ofNullable(member));
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
 
@@ -101,6 +102,7 @@ class CommentServiceTest extends DummyObject {
             Member boardOwner = mockMember("boardOwnerGithubId");
             board = mockBoard(boardOwner);
 
+            // stub
             BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.ofNullable(member));
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
 
@@ -121,32 +123,32 @@ class CommentServiceTest extends DummyObject {
             // when & then
             assertThatThrownBy(() -> commentService.saveComment(dto, githubId, boardId))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage("금지어가 포함되어 있습니다.");
+                    .hasMessage(ErrorCode.BAD_WORD.getMessage());
         }
 
         @DisplayName("댓글을 입력할 경우 게시글이 존재하지 않을 경우 에러가 발생해야 한다.")
         @Test
         void notFoundBoardError() {
-            // given
+            // given & stub
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> commentService.saveComment(dto, githubId, boardId))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage("해당 게시판을 찾을 수 없습니다.");
+                    .hasMessage(ErrorCode.NOT_FOUND_BOARD.getMessage());
         }
 
         @DisplayName("존재하지 않는 사용자 Key로 댓글을 입력할 경우 에러가 발생해야 한다.")
         @Test
         void notLoginError() {
-            // given
+            // given & stub
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
             BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> commentService.saveComment(dto, githubId, boardId))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage("찾을 수 없는 회원 계정입니다.");
+                    .hasMessage(ErrorCode.NOT_FOUND_MEMBER.getMessage());
         }
     }
 

--- a/src/test/java/com/twoclock/gitconnect/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/twoclock/gitconnect/domain/comment/service/CommentServiceTest.java
@@ -11,6 +11,7 @@ import com.twoclock.gitconnect.domain.notification.entity.constants.Notification
 import com.twoclock.gitconnect.domain.notification.service.NotificationService;
 import com.twoclock.gitconnect.global.dummy.DummyObject;
 import com.twoclock.gitconnect.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -43,22 +44,31 @@ class CommentServiceTest extends DummyObject {
     @Mock
     BoardRepository boardRepository;
 
+    private CommentRegistReqDto dto;
+    private Member member;
+    private Board board;
+    private String githubId;
+    private Long boardId;
+
+
 
     @Nested
     @DisplayName("Comment 등록 테스트")
     class SaveCommentTest {
 
+        @BeforeEach
+        void setUp() {
+            githubId = "githubId";
+            boardId = 1L;
+            dto = new CommentRegistReqDto("댓글 내용");
+            member = mockMember(githubId);
+            board = mockBoard(member);
+        }
+
         @DisplayName("댓글을 입력할 경우 정상적으로 등록되어야 한다.")
         @Test
         void saveComment() {
             // given
-            String githubId = "githubId";
-            Long boardId = 1L;
-            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
-            Member boardOwner = mockMember("boardOwnerGithubId");
-            Member member = mockMember(githubId);
-            Board board = mockBoard(boardOwner);
-
             BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.ofNullable(member));
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
 
@@ -73,12 +83,6 @@ class CommentServiceTest extends DummyObject {
         @Test
         void notSentNotify() {
             // given
-            String githubId = "githubId";
-            Long boardId = 1L;
-            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
-            Member member = mockMember(githubId);
-            Board board = mockBoard(member);
-
             BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.ofNullable(member));
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
 
@@ -94,12 +98,8 @@ class CommentServiceTest extends DummyObject {
         @Test
         void sentNotify() {
             // given
-            String githubId = "githubId";
-            Long boardId = 1L;
-            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
             Member boardOwner = mockMember("boardOwnerGithubId");
-            Member member = mockMember(githubId);
-            Board board = mockBoard(boardOwner);
+            board = mockBoard(boardOwner);
 
             BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.ofNullable(member));
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
@@ -116,9 +116,7 @@ class CommentServiceTest extends DummyObject {
         @Test
         void badWordError() {
             // given
-            String githubId = "githubId";
-            Long boardId = 1L;
-            CommentRegistReqDto dto = new CommentRegistReqDto("시발");
+            dto = new CommentRegistReqDto("시발");
 
             // when & then
             assertThatThrownBy(() -> commentService.saveComment(dto, githubId, boardId))
@@ -130,10 +128,6 @@ class CommentServiceTest extends DummyObject {
         @Test
         void notFoundBoardError() {
             // given
-            String githubId = "githubId";
-            Long boardId = 1L;
-            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
-
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.empty());
 
             // when & then
@@ -146,12 +140,6 @@ class CommentServiceTest extends DummyObject {
         @Test
         void notLoginError() {
             // given
-            String githubId = "githubId";
-            Long boardId = 1L;
-            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
-            Member member = mockMember(githubId);
-            Board board = mockBoard(member);
-
             BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
             BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.empty());
 

--- a/src/test/java/com/twoclock/gitconnect/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/twoclock/gitconnect/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,74 @@
+package com.twoclock.gitconnect.domain.comment.service;
+
+import com.twoclock.gitconnect.domain.board.entity.Board;
+import com.twoclock.gitconnect.domain.board.repository.BoardRepository;
+import com.twoclock.gitconnect.domain.comment.dto.CommentRegistReqDto;
+import com.twoclock.gitconnect.domain.comment.entity.Comment;
+import com.twoclock.gitconnect.domain.comment.repository.CommentRepository;
+import com.twoclock.gitconnect.domain.member.entity.Member;
+import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
+import com.twoclock.gitconnect.domain.notification.entity.constants.NotificationType;
+import com.twoclock.gitconnect.domain.notification.service.NotificationService;
+import com.twoclock.gitconnect.global.dummy.DummyObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest extends DummyObject {
+
+    @InjectMocks
+    CommentService commentService;
+    @Mock
+    NotificationService notificationService;
+    @Mock
+    CommentRepository commentRepository;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    BoardRepository boardRepository;
+
+
+    @Nested
+    @DisplayName("Comment 등록 테스트")
+    class SaveCommentTest {
+
+        @DisplayName("댓글을 입력할 경우 정상적으로 등록되어야 한다.")
+        @Test
+        void saveComment() {
+            // given
+            String githubId = "githubId";
+            Long boardId = 1L;
+            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
+            Member boardOwner = mockMember("boardOwnerGithubId");
+            Member member = mockMember(githubId);
+            Board board = mockBoard(boardOwner);
+
+            BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.ofNullable(member));
+            BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
+
+            // when
+            commentService.saveComment(dto, githubId, boardId);
+
+            // then
+            verify(commentRepository, times(1)).save(any(Comment.class));
+            verify(notificationService, times(1))
+                    .addNotificationInfo(eq(board.getMember()), eq(NotificationType.COMMENT), eq(member.getLogin()));
+        }
+    }
+
+
+}

--- a/src/test/java/com/twoclock/gitconnect/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/twoclock/gitconnect/domain/comment/service/CommentServiceTest.java
@@ -10,6 +10,7 @@ import com.twoclock.gitconnect.domain.member.repository.MemberRepository;
 import com.twoclock.gitconnect.domain.notification.entity.constants.NotificationType;
 import com.twoclock.gitconnect.domain.notification.service.NotificationService;
 import com.twoclock.gitconnect.global.dummy.DummyObject;
+import com.twoclock.gitconnect.global.exception.CustomException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -65,8 +67,98 @@ class CommentServiceTest extends DummyObject {
 
             // then
             verify(commentRepository, times(1)).save(any(Comment.class));
+        }
+
+        @DisplayName("댓글을 입력할 경우 작성자와 게시글 작성자가 동일한 경우 알람이 발송되지 않아야 한다.")
+        @Test
+        void notSentNotify() {
+            // given
+            String githubId = "githubId";
+            Long boardId = 1L;
+            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
+            Member member = mockMember(githubId);
+            Board board = mockBoard(member);
+
+            BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.ofNullable(member));
+            BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
+
+            // when
+            commentService.saveComment(dto, githubId, boardId);
+
+            // then
+            verify(notificationService, times(0))
+                    .addNotificationInfo(eq(board.getMember()), eq(NotificationType.COMMENT), eq(member.getLogin()));
+        }
+
+        @DisplayName("댓글을 입력할 경우 작성자와 게시글 작성자가 동일하지 않은 경우 알람이 발송되어야 한다.")
+        @Test
+        void sentNotify() {
+            // given
+            String githubId = "githubId";
+            Long boardId = 1L;
+            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
+            Member boardOwner = mockMember("boardOwnerGithubId");
+            Member member = mockMember(githubId);
+            Board board = mockBoard(boardOwner);
+
+            BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.ofNullable(member));
+            BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
+
+            // when
+            commentService.saveComment(dto, githubId, boardId);
+
+            // then
             verify(notificationService, times(1))
                     .addNotificationInfo(eq(board.getMember()), eq(NotificationType.COMMENT), eq(member.getLogin()));
+        }
+
+        @DisplayName("댓글을 입력할 경우 비속어가 포함되어 있을 경우 에러가 발생해야 한다.")
+        @Test
+        void badWordError() {
+            // given
+            String githubId = "githubId";
+            Long boardId = 1L;
+            CommentRegistReqDto dto = new CommentRegistReqDto("시발");
+
+            // when & then
+            assertThatThrownBy(() -> commentService.saveComment(dto, githubId, boardId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("금지어가 포함되어 있습니다.");
+        }
+
+        @DisplayName("댓글을 입력할 경우 게시글이 존재하지 않을 경우 에러가 발생해야 한다.")
+        @Test
+        void notFoundBoardError() {
+            // given
+            String githubId = "githubId";
+            Long boardId = 1L;
+            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
+
+            BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> commentService.saveComment(dto, githubId, boardId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("해당 게시판을 찾을 수 없습니다.");
+        }
+
+        @DisplayName("존재하지 않는 사용자 Key로 댓글을 입력할 경우 에러가 발생해야 한다.")
+        @Test
+        void notLoginError() {
+            // given
+            String githubId = "githubId";
+            Long boardId = 1L;
+            CommentRegistReqDto dto = new CommentRegistReqDto("댓글 내용");
+            Member member = mockMember(githubId);
+            Board board = mockBoard(member);
+
+            BDDMockito.given(boardRepository.findById(boardId)).willReturn(Optional.ofNullable(board));
+            BDDMockito.given(memberRepository.findByGitHubId(githubId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> commentService.saveComment(dto, githubId, boardId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("찾을 수 없는 회원 계정입니다.");
         }
     }
 


### PR DESCRIPTION
## 관련 이슈

* #121 

## 변경 사항

> **댓글 관련 서비스 계층 테스트 코드 작성**

- service method를 대부분 `void` 형태로 처리하다 보니 값 검증에 대한 방법이 `verify` 말고는 딱히 생각나지 않네요

```
/** 테스트 목록*/

1. Comment 정상 입력 시 성공 
2. Comment 작성자와 Board 작성자가 동일 한 경우 알람 발송 X
3. Comment 작성자와 Board 작성자가 동일하지 않은 경우 알람 발송
4. Comment 내용에 비속어가 존재할 경우 에러 반환
5. 작성된 Board가 존재하지 않을 경우 등록 X
6. 잘못된 사용자 key 사용 경우 Comment 작성 불가
```

![image](https://github.com/user-attachments/assets/3b249529-bd6b-47c3-ab14-8c118a5c260a)

추가적으로 테스트 코드 처음 작성할 때 `통합 테스트` 도 고려하여  `IntegrationTestSupport` 라는 Class를 생성해 놓긴 했습니다.
근데 생각해보니 통합테스트까지 처리할 시간적 여유가 있을지 모르겠네요

추후 개발 상황 봐서 불필요하다 싶으면 삭제하겠습니다.



## 체크 목록

- [X] 테스트 코드를 작성 하셨나요?